### PR TITLE
Added warning when no matching expressions are found

### DIFF
--- a/src/util/FileUtils.cpp
+++ b/src/util/FileUtils.cpp
@@ -66,6 +66,16 @@ std::vector<std::string> FileUtils::getFilesByExpression(
         // Register filePath because it matches regexp
         filePaths.push_back(di->path().string());
     }
+
+  if (filePaths.empty())
+  {
+    std::stringstream ss;
+    ss << "Warning: No matching files were found "
+          "in efilepath directory. "
+          "Check regular expression.";
+    logging::WARN(ss.str());
+  }
+
     return filePaths;
 }
 


### PR DESCRIPTION
When looking for files using the pattern provided in "efilepath",
is possible to give a bad pattern, yielding 0 files found by the objloader, xyzloader or detailedVoxelsloader. In that
case, a logging::WARN() verbose level message is printed in the terminal (-v must be provided in the execution)