### PR TITLE
Added possibility of writing LAS v1.0 files when using PyHelios

### DIFF
--- a/pyhelios_demo/helios.py
+++ b/pyhelios_demo/helios.py
@@ -97,7 +97,8 @@ if __name__ == '__main__':
         args.assets_path,
         args.output_path,
         args.number_of_threads,  # Num Threads
-        args.las_output_flag,  # LAS output
+        args.las_output_flag,  # LAS v1.4 output
+        args.las10_output_flag,# LAS v1.0 output
         args.zip_output_flag,  # ZIP output
     )
 

--- a/pyhelios_demo/pyhelios_argparser.py
+++ b/pyhelios_demo/pyhelios_argparser.py
@@ -38,6 +38,9 @@ parser.add_argument('--seed', dest='randomness_seed',
 parser.add_argument('--lasOutput', dest='las_output_flag', action='store_const', const=True, default=False,
                     help='Use this flag to generate the output point cloud in LAS format.')
 
+parser.add_argument('--las10', dest='las10_output_flag', action='store_const', const=True, default=False,
+                    help='Use this flag along with --lasOutput to write LAS v1.0 files.')
+
 parser.add_argument('--zipOutput', dest='zip_output_flag', action='store_const', const=True, default=False,
                     help='Use this flag to generate compressed output.')
 

--- a/pyhelios_demo/pyhelios_argparser.py
+++ b/pyhelios_demo/pyhelios_argparser.py
@@ -36,10 +36,10 @@ parser.add_argument('--seed', dest='randomness_seed',
                          'By default: a random seed is generated.')
 
 parser.add_argument('--lasOutput', dest='las_output_flag', action='store_const', const=True, default=False,
-                    help='Use this flag to generate the output point cloud in LAS format.')
+                    help='Use this flag to generate the output point cloud in LAS v1.4 format.')
 
 parser.add_argument('--las10', dest='las10_output_flag', action='store_const', const=True, default=False,
-                    help='Use this flag along with --lasOutput to write LAS v1.0 files.')
+                    help='Use this flag to write LAS v1.0 files.')
 
 parser.add_argument('--zipOutput', dest='zip_output_flag', action='store_const', const=True, default=False,
                     help='Use this flag to generate compressed output.')

--- a/pyhelios_demo/pyhelios_script.py
+++ b/pyhelios_demo/pyhelios_script.py
@@ -152,8 +152,9 @@ if __name__ == '__main__':
         args.assets_path,
         args.output_path,
         args.number_of_threads,  # Num Threads
-        args.las_output_flag,  # LAS output
-        args.zip_output_flag,  # ZIP output
+        args.las_output_flag,    # LAS v1.4 output
+        args.las10_output_flag,  # LAS v1.0 output
+        args.zip_output_flag,    # ZIP output
     )
 
     # Load the survey file.

--- a/pyheliostools/simulation_build.py
+++ b/pyheliostools/simulation_build.py
@@ -21,6 +21,7 @@ class SimulationBuild:
         outputDir,
         numThreads,
         lasOutput,
+        las10,
         zipOutput,
         copy=False
     ):
@@ -33,6 +34,7 @@ class SimulationBuild:
             outputDir,
             numThreads,
             lasOutput,
+            las10,
             zipOutput
         )
 

--- a/pyheliostools/simulation_builder.py
+++ b/pyheliostools/simulation_builder.py
@@ -32,6 +32,7 @@ class SimulationBuilder:
         outputDir -- Path to output directory
         numThreads -- Number of threads (0 means as many as possible)
         lasOutput -- LAS output format flag
+        las10     -- LAS v1.0 output format flag
         zipOutput -- Zip output format flag (can be unzipped with Helios++)
         simFrequency -- Simulation control frequency (do not mismatch with
             the simulation operating frequency)
@@ -92,6 +93,7 @@ class SimulationBuilder:
             self.outputDir,
             self.numThreads,
             self.lasOutput,
+            self.las10,
             self.zipOutput
         )
         build.sim.simFrequency = self.simFrequency
@@ -158,6 +160,10 @@ class SimulationBuilder:
     def setLasOutput(self, lasOutput):
         self.validateBoolean(lasOutput)
         self.lasOutput = lasOutput
+
+    def setLas10(self, las10):
+        self.validateBoolean(las10)
+        self.las10 = las10
 
     def setZipOutput(self, zipOutput):
         self.validateBoolean(zipOutput)

--- a/src/LidarSim.cpp
+++ b/src/LidarSim.cpp
@@ -237,6 +237,7 @@ void LidarSim::init(
         outputPath,
         njobs,
         lasOutput,
+        las10,
         zipOutput
 	);
 

--- a/src/LidarSim.h
+++ b/src/LidarSim.h
@@ -31,7 +31,6 @@ public:
      * @param lasOutput Flag to specify LAS output format. True implies using
      *  LAS output format, false implies don't
      * @param las10 Flag to specify that the output format mmust be LAS v1.0.
-     * Used along with lasOutput
      * @param zipOutput Flag to specify output zipping. True implies output
      *  will be zipped, false means it will not
      * @param fixedIncidenceAngle Flag to specify usage of fixed incidence

--- a/src/LidarSim.h
+++ b/src/LidarSim.h
@@ -30,7 +30,7 @@ public:
      *  false means previously built scene will be used when available
      * @param lasOutput Flag to specify LAS output format. True implies using
      *  LAS output format, false implies don't
-     * @param las10 Flag to specify that the output format mmust be LAS v1.0.
+     * @param las10 Flag to specify that the output format must be LAS v1.0.
      * @param zipOutput Flag to specify output zipping. True implies output
      *  will be zipped, false means it will not
      * @param fixedIncidenceAngle Flag to specify usage of fixed incidence

--- a/src/LidarSim.h
+++ b/src/LidarSim.h
@@ -30,6 +30,8 @@ public:
      *  false means previously built scene will be used when available
      * @param lasOutput Flag to specify LAS output format. True implies using
      *  LAS output format, false implies don't
+     * @param las10 Flag to specify that the output format mmust be LAS v1.0.
+     * Used along with lasOutput
      * @param zipOutput Flag to specify output zipping. True implies output
      *  will be zipped, false means it will not
      * @param fixedIncidenceAngle Flag to specify usage of fixed incidence

--- a/src/pybinds/PyHelios.cpp
+++ b/src/pybinds/PyHelios.cpp
@@ -67,6 +67,7 @@ BOOST_PYTHON_MODULE(pyhelios){
             std::string,
             size_t,
             bool,
+            bool,
             bool
         >())
         .def(
@@ -153,6 +154,11 @@ BOOST_PYTHON_MODULE(pyhelios){
             "lasOutput",
             &PyHeliosSimulation::getLasOutput,
             &PyHeliosSimulation::setLasOutput
+        )
+        .add_property(
+            "las10",
+            &PyHeliosSimulation::getLas10,
+            &PyHeliosSimulation::setLas10
         )
         .add_property(
             "zipOutput",

--- a/src/pybinds/PyHeliosSimulation.cpp
+++ b/src/pybinds/PyHeliosSimulation.cpp
@@ -16,9 +16,11 @@ PyHeliosSimulation::PyHeliosSimulation(
     std::string outputPath,
     size_t numThreads,
     bool lasOutput,
+    bool las10,
     bool zipOutput
 ){
     this->lasOutput = lasOutput;
+    this->las10 = las10;
     this->zipOutput = zipOutput;
     this->surveyPath = surveyPath;
     this->assetsPath = assetsPath;
@@ -64,6 +66,7 @@ void PyHeliosSimulation::start (){
     }
 
     survey->scanner->detector->lasOutput = lasOutput;
+    survey->scanner->detector->las10 = las10;
     survey->scanner->detector->zipOutput = zipOutput;
     playback = std::shared_ptr<SurveyPlayback>(
         new SurveyPlayback(
@@ -71,6 +74,7 @@ void PyHeliosSimulation::start (){
             outputPath,
             numThreads,
             lasOutput,
+            las10,
             zipOutput,
             exportToFile
         )
@@ -246,6 +250,7 @@ PyHeliosSimulation * PyHeliosSimulation::copy(){
     phs->survey = std::make_shared<Survey>(*survey);
     phs->callback = this->callback;
     phs->lasOutput = this->lasOutput;
+    phs->las10     = this->las10;
     phs->zipOutput = this->zipOutput;
     phs->exportToFile = this->exportToFile;
     phs->setSimFrequency(getSimFrequency());

--- a/src/pybinds/PyHeliosSimulation.h
+++ b/src/pybinds/PyHeliosSimulation.h
@@ -37,6 +37,7 @@ private:
     boost::thread * thread = nullptr;
     std::shared_ptr<PySimulationCycleCallback> callback = nullptr;
     bool lasOutput = false;
+    bool las10     = false;
     bool zipOutput = false;
 public:
     bool finalOutput = true;
@@ -60,6 +61,7 @@ public:
         std::string outputPath = "output/",
         size_t numThreads = 0,
         bool lasOutput = false,
+        bool las10     = false,
         bool zipOutput = false
     );
     virtual ~PyHeliosSimulation();
@@ -188,19 +190,28 @@ public:
         survey->scanner->cycleMeasurements = nullptr;
         survey->scanner->cycleMeasurementsMutex = nullptr;
     }
-    void setLasOutput(double lasOutput){
+    double getLasOutput(){return lasOutput;}
+    void setLasOutput(double lasOutput_){
         if(started) throw PyHeliosException(
             "Cannot modify LAS output flag for already started simulations."
         );
-        this->lasOutput = lasOutput;
+        this->lasOutput = lasOutput_;
     }
-    double getLasOutput(){return lasOutput;}
+
+    double getLas10(){return las10;}
+    void setLas10(double las10_){
+    if(started) throw PyHeliosException(
+          "Cannot modify LAS v1.0 output flag for already started simulations."
+      );
+    this->las10 = las10_;
+  }
+
     double getZipOutput(){return zipOutput;}
-    void setZipOutput(bool zipOutput){
+    void setZipOutput(bool zipOutput_){
         if(started) throw PyHeliosException(
             "Cannot modify ZIP output flag for already started simulations."
         );
-        this->zipOutput = zipOutput;
+        this->zipOutput = zipOutput_;
     }
 
     // ***  CONTROL FUNCTIONS  *** //

--- a/src/scanner/detector/AbstractDetector.cpp
+++ b/src/scanner/detector/AbstractDetector.cpp
@@ -32,6 +32,7 @@ WriterType AbstractDetector::chooseWriterType() {
   // Get the type of writer to be created
   WriterType wt;
   if (lasOutput) wt = las10 ? las10Type : las14Type;
+  else if (las10) wt = las10Type;
   else if (zipOutput) wt = zipType;
   else wt = simpleType;
 

--- a/src/surveyplayback/SurveyPlayback.cpp
+++ b/src/surveyplayback/SurveyPlayback.cpp
@@ -26,11 +26,13 @@ SurveyPlayback::SurveyPlayback(
     size_t numThreads,
     bool lasOutput,
     bool zipOutput,
+    bool las10,
     bool exportToFile
 ):
     Simulation(numThreads, survey->scanner->detector->cfg_device_accuracy_m),
     lasOutput(lasOutput),
     zipOutput(zipOutput),
+    las10(las10),
     outputPath(outputPath)
 {
     this->mSurvey = survey;

--- a/src/surveyplayback/SurveyPlayback.cpp
+++ b/src/surveyplayback/SurveyPlayback.cpp
@@ -25,14 +25,14 @@ SurveyPlayback::SurveyPlayback(
     const std::string outputPath,
     size_t numThreads,
     bool lasOutput,
-    bool zipOutput,
     bool las10,
+    bool zipOutput,
     bool exportToFile
 ):
     Simulation(numThreads, survey->scanner->detector->cfg_device_accuracy_m),
     lasOutput(lasOutput),
-    zipOutput(zipOutput),
     las10(las10),
+    zipOutput(zipOutput),
     outputPath(outputPath)
 {
     this->mSurvey = survey;

--- a/src/surveyplayback/SurveyPlayback.cpp
+++ b/src/surveyplayback/SurveyPlayback.cpp
@@ -205,8 +205,7 @@ string SurveyPlayback::getCurrentOutputPath() {
 string SurveyPlayback::getTrajectoryOutputPath(){
     stringstream ss;
     ss << getLegOutputPrefix();
-    if(zipOutput) ss << "_trajectory.bin";
-    else ss << "_trajectory.txt";
+    ss << "_trajectory.txt";
     return ss.str();
 }
 
@@ -376,16 +375,9 @@ void SurveyPlayback::prepareOutput(){
     if(mSurvey->scanner->trajectoryTimeInterval != 0.0){
         std::string trajectoryOutputPath = mOutputFilePathString +
                                            getTrajectoryOutputPath();
-        if(zipOutput){
-            mSurvey->scanner->setTrajectoryFileWriter(
-                std::make_shared<ZipSyncFileWriter>(trajectoryOutputPath)
+        mSurvey->scanner->setTrajectoryFileWriter(
+            std::make_shared<SimpleSyncFileWriter>(trajectoryOutputPath)
             );
-        }
-        else{
-            mSurvey->scanner->setTrajectoryFileWriter(
-                std::make_shared<SimpleSyncFileWriter>(trajectoryOutputPath)
-            );
-        }
     }
 }
 

--- a/src/surveyplayback/SurveyPlayback.h
+++ b/src/surveyplayback/SurveyPlayback.h
@@ -27,8 +27,7 @@ public:
 	 */
 	bool lasOutput = false;
         /**
-         * @brief Flag to specify if LAS output must be LAS v1.0. Used along
-         * with --lasOutput
+         * @brief Flag to specify if LAS output must be LAS v1.0.
          */
         bool las10 = false;
 	/**

--- a/src/surveyplayback/SurveyPlayback.h
+++ b/src/surveyplayback/SurveyPlayback.h
@@ -109,7 +109,7 @@ public:
      * @param lasOutput Flag to specify LAS format for the output (true) or not
      *  (false)
      * @param las10 Flag to specify if LAS output must be LAS v1.0 (true) or not
-     * (false). Used along with --lasOutput
+     * (false).
      * @param zipOutput Flag to specify if output must be zipped (true) or not
      *  (false)
      * @param exportToFile Flag to specify if output must be written to a file

--- a/src/surveyplayback/SurveyPlayback.h
+++ b/src/surveyplayback/SurveyPlayback.h
@@ -26,6 +26,11 @@ public:
 	 *  or not (false)
 	 */
 	bool lasOutput = false;
+        /**
+         * @brief Flag to specify if LAS output must be LAS v1.0. Used along
+         * with --lasOutput
+         */
+        bool las10 = false;
 	/**
 	 * @brief Flag to specify if output must be zipped (true) or not (false)
 	 */
@@ -103,11 +108,14 @@ public:
      * @param numThreads Number of threads to be used
      * @param lasOutput Flag to specify LAS format for the output (true) or not
      *  (false)
+     * @param las10 Flag to specify if LAS output must be LAS v1.0 (true) or not
+     * (false). Used along with --lasOutput
      * @param zipOutput Flag to specify if output must be zipped (true) or not
      *  (false)
      * @param exportToFile Flag to specify if output must be written to a file
      *  (true) or not (false)
      * @see SurveyPlayback::lasOutput
+     * @see SurveyPlayback::las10
      * @see SurveyPlayback::zipOutput
      * @see SurveyPlayback::outputPath
      * @see Survey
@@ -117,6 +125,7 @@ public:
         const std::string outputPath,
         size_t numThreads,
         bool lasOutput,
+        bool las10,
         bool zipOutput,
         bool exportToFile=true
     );


### PR DESCRIPTION
The behaviour is exactly the same as the implemented in the main program. Nevertheless, I may have spotted an incongruency in the trajectory output formats:

![image](https://user-images.githubusercontent.com/83340465/121175591-82fb0480-c85b-11eb-8dd3-98f368f46330.png)

Could anyone confirm that these are the expected trajectory formats? I expected to have .bin formats only when the flag 
```--zipOutput``` is passed to the execution.


