### PR TITLE
Fixed condition when defining the separator to be used.

### DIFF
--- a/src/assetloading/geometryfilter/XYZPointCloudFileLoader.cpp
+++ b/src/assetloading/geometryfilter/XYZPointCloudFileLoader.cpp
@@ -27,7 +27,7 @@ ScenePart* XYZPointCloudFileLoader::run() {
 
     // Read separator
 	string const & pSep = boost::get<string const &>(params["separator"]);
-	if (pSep.empty()) separator = pSep;
+	if (!pSep.empty()) separator = pSep;
 
 	// Read voxel size
     double pVoxelSize = boost::get<double>(params["voxelSize"]);


### PR DESCRIPTION
Fixed as @han16nah and @lwiniwar pointed in #62 