### PR TITLE
Fixed math constants usage for windows version

### DIFF
--- a/src/maths/MathConstants.h
+++ b/src/maths/MathConstants.h
@@ -53,3 +53,11 @@ const double ALMOST_MINUS_1 = -0.9999999999;
  * @brief Constant representing a very close from below to 1 number
  */
 const double ALMOST_PLUS_1 = 0.9999999999;
+
+/**
+ * \f[
+ *  \sqrt{2}
+ * \f]
+ */
+
+const double SQRT2 = 1.4142135623730951;

--- a/src/maths/rigidmotion/RigidMotionR3Factory.cpp
+++ b/src/maths/rigidmotion/RigidMotionR3Factory.cpp
@@ -1,5 +1,6 @@
 #include <rigidmotion/RigidMotionR3Factory.h>
 #include <rigidmotion/RigidMotionException.h>
+#include <maths/MathConstants.h>
 
 using namespace rigidmotion;
 
@@ -29,8 +30,8 @@ RigidMotion RigidMotionR3Factory::makeReflectionFast(colvec const orthonormal){
     // Compute alpha vector
     colvec alpha(3);
     if(orthonormal[0] == 0.0 && orthonormal[1] == 0.0){
-        alpha[0] = M_SQRT2;
-        alpha[1] = M_SQRT2;
+        alpha[0] = SQRT2;
+        alpha[1] = SQRT2;
         alpha[2] = 0;
     }
     else if(orthonormal[1] == 0.0){


### PR DESCRIPTION
The usage of the constant for the square root of 2 was placed into Helios MathConstants header. It must be accessible OS-independently now.