### PR TITLE
Adapted Dockerfile to use the last Helios release.

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -4,7 +4,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /home
 RUN apt update && apt install -y gcc g++ cmake make git wget unzip && \
-git clone https://github.com/3dgeo-heidelberg/helios.git
+git clone --branch v1.0.9 https://github.com/3dgeo-heidelberg/helios.git
+
+WORKDIR /home/helios
+RUN git switch -c v1.0.9
 
 WORKDIR /home/helios/lib
 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -4,10 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /home
 RUN apt update && apt install -y gcc g++ cmake make git wget unzip && \
-git clone --branch v1.0.9 https://github.com/3dgeo-heidelberg/helios.git
-
-WORKDIR /home/helios
-RUN git switch -c v1.0.9
+git clone -b main https://github.com/3dgeo-heidelberg/helios.git
 
 WORKDIR /home/helios/lib
 


### PR DESCRIPTION
This is a quick fix related to issue #100 (yay!) . The idea is to parametrice the version so it can be selected by the user or, if not selected, the parameter should be pointing to the last stable release.