### PR TITLE
Finalize scene loading UNS with given seed

### DIFF
--- a/src/scene/Scene.cpp
+++ b/src/scene/Scene.cpp
@@ -67,7 +67,7 @@ bool Scene::finalizeLoading(bool const safe) {
   if (primitives.empty()) return false;
 
   // #####   UPDATE PRIMITIVES ON FINISH LOADING   #####
-  UniformNoiseSource<double> uns(-1, 1);
+  UniformNoiseSource<double> uns(*DEFAULT_RG, -1, 1);
   for (Primitive *p : primitives) {
     p->onFinishLoading(uns);
   }


### PR DESCRIPTION
UniformNoiseSource for scene finalize loading is now using default randomness generator. In consequence, scaled detailed voxels random shift should now be reproducible