### PR TITLE
Fixed bug causing legStrips not being correctly written.

### DIFF
--- a/src/sim/core/SurveyPlayback.cpp
+++ b/src/sim/core/SurveyPlayback.cpp
@@ -48,6 +48,9 @@ SurveyPlayback::SurveyPlayback(
 	this->exitAtEnd = true;
 	this->exportToFile = exportToFile;
 
+  // Activate lasOutput if only --las10 (and not --lasOutput) flag is passed.
+  if (!this->lasOutput && this->las10) this->lasOutput = true;
+
 	// ######## BEGIN Create part of the leg point cloud file path #######
 	auto t = std::time(nullptr);
 	auto tm = std::localtime(&t);


### PR DESCRIPTION
The error was caused due to the non activation of the lasOutput
flag when only --las10 flag was passed as an input argument
to the execution.