### PR TITLE
Fix expected size

### DIFF
--- a/pytests/test_demo_scenes.py
+++ b/pytests/test_demo_scenes.py
@@ -140,7 +140,7 @@ def eval_detailedVoxels_uls(dirname):
     assert (dirname / 'leg000_points.las').exists()
     assert abs((dirname / 'leg000_points.las').stat().st_size - 404_517) < MAX_DIFFERENCE_BYTES
     assert (dirname / 'leg000_trajectory.txt').exists()
-    assert abs((dirname / 'leg000_trajectory.txt').stat().st_size - 1_250) < MAX_DIFFERENCE_BYTES
+    assert abs((dirname / 'leg000_trajectory.txt').stat().st_size - 2_541) < MAX_DIFFERENCE_BYTES
     with open(dirname / 'leg000_trajectory.txt', 'r') as f:
         for _ in range(6):
             next(f)


### PR DESCRIPTION
TrajectoryTimeInterval was not properly handled in previous versions. Updating the test to fit the new expected size when using TTI=0.01 instead of 0.015