### PR TITLE
Fix noground scenes

### DIFF
--- a/data/surveys/dyn/tls_tree1_dyn.xml
+++ b/data/surveys/dyn/tls_tree1_dyn.xml
@@ -3,27 +3,27 @@
         <scannerSettings id="tls" active="true" pulseFreq_hz="600000" verticalResolution_deg="0.04" horizontalResolution_deg="0.04"/>
         <survey name="tls_tree1_dyn" platform="data/platforms.xml#tripod" scanner="data/scanners_tls.xml#riegl_vz400" scene="data/scenes/dyn/tree1_dyn.xml#tree1">
             <leg>
-            <platformSettings x="3.0000" y="0.0000" z="0" onGround="true"/>
+            <platformSettings x="3.0000" y="0.0000" z="0" onGround="false"/>
             <scannerSettings template="tls" headRotateStart_deg="45.0000" headRotateStop_deg="135.0000" trajectoryTimeInterval_s="0.05"/>
         </leg>
         <leg>
-            <platformSettings x="1.5000" y="2.5981" z="0" onGround="true"/>
+            <platformSettings x="1.5000" y="2.5981" z="0" onGround="false"/>
             <scannerSettings template="tls" headRotateStart_deg="105.0000" headRotateStop_deg="195.0000" trajectoryTimeInterval_s="0.05"/>
         </leg>
         <leg>
-            <platformSettings x="-1.5000" y="2.5981" z="0" onGround="true"/>
+            <platformSettings x="-1.5000" y="2.5981" z="0" onGround="false"/>
             <scannerSettings template="tls" headRotateStart_deg="-195.0000" headRotateStop_deg="-105.0000" trajectoryTimeInterval_s="0.05"/>
         </leg>
         <leg>
-            <platformSettings x="-3.0000" y="0.0000" z="0" onGround="true"/>
+            <platformSettings x="-3.0000" y="0.0000" z="0" onGround="false"/>
             <scannerSettings template="tls" headRotateStart_deg="-135.0000" headRotateStop_deg="-45.0000" trajectoryTimeInterval_s="0.05"/>
         </leg>
         <leg>
-            <platformSettings x="-1.5000" y="-2.5981" z="0" onGround="true"/>
+            <platformSettings x="-1.5000" y="-2.5981" z="0" onGround="false"/>
             <scannerSettings template="tls" headRotateStart_deg="-75.0000" headRotateStop_deg="15.0000" trajectoryTimeInterval_s="0.05"/>
         </leg>
         <leg>
-            <platformSettings x="1.5000" y="-2.5981" z="0" onGround="true"/>
+            <platformSettings x="1.5000" y="-2.5981" z="0" onGround="false"/>
             <scannerSettings template="tls" headRotateStart_deg="-15.0000" headRotateStop_deg="75.0000" trajectoryTimeInterval_s="0.05"/>
         </leg>
         

--- a/data/surveys/dyn/tls_tree1_static.xml
+++ b/data/surveys/dyn/tls_tree1_static.xml
@@ -3,27 +3,27 @@
         <scannerSettings id="tls" active="true" pulseFreq_hz="600000" verticalResolution_deg="0.04" horizontalResolution_deg="0.04"/>
         <survey name="tls_tree1_static" platform="data/platforms.xml#tripod" scanner="data/scanners_tls.xml#riegl_vz400" scene="data/scenes/dyn/tree1_static.xml#tree1">
             <leg>
-            <platformSettings x="3.0000" y="0.0000" z="0" onGround="true"/>
+            <platformSettings x="3.0000" y="0.0000" z="0" onGround="false"/>
             <scannerSettings template="tls" headRotateStart_deg="45.0000" headRotateStop_deg="135.0000" trajectoryTimeInterval_s="0.05"/>
         </leg>
         <leg>
-            <platformSettings x="1.5000" y="2.5981" z="0" onGround="true"/>
+            <platformSettings x="1.5000" y="2.5981" z="0" onGround="false"/>
             <scannerSettings template="tls" headRotateStart_deg="105.0000" headRotateStop_deg="195.0000" trajectoryTimeInterval_s="0.05"/>
         </leg>
         <leg>
-            <platformSettings x="-1.5000" y="2.5981" z="0" onGround="true"/>
+            <platformSettings x="-1.5000" y="2.5981" z="0" onGround="false"/>
             <scannerSettings template="tls" headRotateStart_deg="-195.0000" headRotateStop_deg="-105.0000" trajectoryTimeInterval_s="0.05"/>
         </leg>
         <leg>
-            <platformSettings x="-3.0000" y="0.0000" z="0" onGround="true"/>
+            <platformSettings x="-3.0000" y="0.0000" z="0" onGround="false"/>
             <scannerSettings template="tls" headRotateStart_deg="-135.0000" headRotateStop_deg="-45.0000" trajectoryTimeInterval_s="0.05"/>
         </leg>
         <leg>
-            <platformSettings x="-1.5000" y="-2.5981" z="0" onGround="true"/>
+            <platformSettings x="-1.5000" y="-2.5981" z="0" onGround="false"/>
             <scannerSettings template="tls" headRotateStart_deg="-75.0000" headRotateStop_deg="15.0000" trajectoryTimeInterval_s="0.05"/>
         </leg>
         <leg>
-            <platformSettings x="1.5000" y="-2.5981" z="0" onGround="true"/>
+            <platformSettings x="1.5000" y="-2.5981" z="0" onGround="false"/>
             <scannerSettings template="tls" headRotateStart_deg="-15.0000" headRotateStop_deg="75.0000" trajectoryTimeInterval_s="0.05"/>
         </leg>
         


### PR DESCRIPTION
Some scenes have no ground, but we specify `onGround="True"` in the survey file. This can lead to problematic behaviors. We are already writing a message through the logging system (DEBUG level), but we should avoid this in our demo surveys. This PR aims to fix these files.