### PR TITLE
Solved issue with voxels-only scenes. 

### DIFF
--- a/src/main/helios_version.cpp
+++ b/src/main/helios_version.cpp
@@ -4,7 +4,7 @@
 
 const char * HELIOS_VERSION = "1.3.0";
 
-const char * HELIOS_GIT_HASH = "147f1e94";
+const char * HELIOS_GIT_HASH = "508f2033";
 
 const char * getHeliosVersion(){
     return HELIOS_VERSION;

--- a/src/scanner/detector/FullWaveformPulseRunnable.cpp
+++ b/src/scanner/detector/FullWaveformPulseRunnable.cpp
@@ -194,7 +194,7 @@ void FullWaveformPulseRunnable::handleSubray(
     );
     subraySimRecord[5] = (rayDirection[0] < 0) == (subrayDirection[0] < 0);
     subraySimRecord[6] = (tMinMax.size()<1) ? 0 : tMinMax[0];
-    subraySimRecord[7] = (tMinMax.size()<1) ? 0 : tMinMax[1];
+    subraySimRecord[7] = (tMinMax.size()<2) ? 0 : tMinMax[1];
     subraySimRecord[8] = subrayDirection.x;
     subraySimRecord[9] = subrayDirection.y;
     subraySimRecord[10] = subrayDirection.z;

--- a/src/scene/primitives/AABB.cpp
+++ b/src/scene/primitives/AABB.cpp
@@ -51,8 +51,8 @@ shared_ptr<AABB> AABB::getForPrimitives(std::vector<Primitive*> & primitives) {
 	double maxZ = numeric_limits<double>::lowest();
 
 	for (Primitive *p : primitives) {
-	    Vertex *v = p->getVertices();
-	    size_t const numVertices = p->getNumVertices();
+        Vertex *v = p->getFullVertices();
+        size_t const numVertices = p->getNumFullVertices();
 	    for(size_t i = 0 ; i < numVertices ; ++i){
 	        double const vx = v[i].pos.x;
             double const vy = v[i].pos.y;


### PR DESCRIPTION
AABB::getForPrimitives now considers bounding boxes instead of vertices.