### PR TITLE
Remove numpy v1 warning

### DIFF
--- a/python/pyhelios/live.py
+++ b/python/pyhelios/live.py
@@ -115,12 +115,6 @@ def helios_live():
         import numpy as np
         import time
 
-        # Check that numpy is major version 1
-        np_major = int(np.__version__.split('.')[0])
-        if np_major > 1:
-            print("WARNING: You are using Open3d together with numpy > 1. To our knowledge this is currently incompatible.")
-            print("Consider downgrading with 'pip install \"numpy<2\"'")
-
         # Create instance of Scene class, generate scene, print scene (if logging v2), and visualize.
         scene = Scene(args.survey_file, args.loggingv2)
         scene.gen_from_xml()


### PR DESCRIPTION
Open3D has released a compatible version: https://github.com/isl-org/Open3D/releases/tag/v0.19.0