### PR TITLE
fix voxel issue (#481)

### DIFF
--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -5,8 +5,8 @@ import pytest
 import shutil
 
 
-TEST_DATA_ARCHIVE = "https://github.com/3dgeo-heidelberg/helios-test-data/releases/download/2025-01-29/data.tar.gz"
-TEST_DATA_CHECKSUM = "d15873ddc06d6dd15d9db31277feefa8064082788c69a80dc403525f2e07dbe5"
+TEST_DATA_ARCHIVE = "https://github.com/3dgeo-heidelberg/helios-test-data/releases/download/2025-02-05/data.tar.gz"
+TEST_DATA_CHECKSUM = "581b9f13ab3dcaf0422a8ab6069ba4534db276c75c098da23dd8ed264a5e7cee"
 
 
 @pytest.fixture

--- a/src/assetloading/geometryfilter/XYZPointCloudFileLoader.cpp
+++ b/src/assetloading/geometryfilter/XYZPointCloudFileLoader.cpp
@@ -271,9 +271,9 @@ void XYZPointCloudFileLoader::prepareVoxelsGrid(
     if(nz == 0) nz = 1;
     nynz = ny * nz;
     maxNVoxels = nx*nynz;
-    xCoeff = nx / deltaX;
-    yCoeff = ny / deltaY;
-    zCoeff = nz / deltaZ;
+    xCoeff = 1/voxelSize;
+    yCoeff = 1/voxelSize;
+    zCoeff = 1/voxelSize;
 
     // Instantiate voxel grid
     if(


### PR DESCRIPTION
This fixes the voxel issue (#481). 
The Coefficient for calculating the number of the voxel has been corrected. 
The code was tested on the tls sphere with different voxel sizes as well as on the pointcloud resulting from the arbaro demo. The results have also been compared to the mesh created by using another voxelizing algorithm.