### PR TITLE
test: gpstime test now system timezone independent

### DIFF
--- a/python/helios/survey.py
+++ b/python/helios/survey.py
@@ -109,7 +109,7 @@ class Survey(Model, cpp_class=_helios.Survey):
             execution_settings.parallelization,
             pulse_thread_pool,
             execution_settings.chunk_size,
-            str(self.gps_time),
+            str(self.gps_time.timestamp()),
             True,
             True,
         )

--- a/tests/python/test_survey.py
+++ b/tests/python/test_survey.py
@@ -87,14 +87,13 @@ def test_survey_run_laspy_output(survey):
 
 def test_set_gpstime(survey):
     survey.gps_time = datetime.now(timezone.utc)
-    # This timestamp is close to the week epoch. GPS Time is a complicated beast.
-    survey.gps_time = "2025-02-09T01:00:09"
+    # This timestamp is at the gps week start.
+    # A timezone must be given to make this system time independent.
+    survey.gps_time = "2025-02-09T00:00:09+00:00"
     with pytest.raises(ValueError):
         survey.gps_time = "foobar"
 
     points, _ = survey.run()
 
     assert np.all(points["gps_time"] > 0)
-    # TODO: This seems to not be time zone agnostic. I get <1 on my machine.
-    #       But on GitHub Actions, I get 3600. This needs proper fixing.
-    assert np.all(points["gps_time"] < 3601)
+    assert np.all(points["gps_time"] < 1)


### PR DESCRIPTION
tl;dr: If in the test a datetime with tz info is used and the date time to posix time conversion in c++ is avoided, the test is reliable. The posix- to gps time conversion is simple enough that I would avoid introducing a external dependency for it.

There are two tz dependent parts, one in c++ and one in python. 
 - In c++, a given datetime string is converted to posix time using the local timezone. If this part instead receives a posix time string, no conversion is performed.
 - Pydantic converts recived time stings or datetimes into tz-aware datetimes. This only works independent of the local time, if a tz is provided from the beginning.

My current changes add a tz in the test, and avoid the posix time calculation in c++ by performing it in the python part.

The posix to gps conversion is relatively straight-forward: `((PosixTime - 315964809L) % 604800L) * 1000000000.` with 315964809L being an offset, and 604800L the time of one week. 

fixes #563