### PR TITLE
Feat/multiassetpath

### DIFF
--- a/python/helios/scene.py
+++ b/python/helios/scene.py
@@ -116,16 +116,7 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         Expects a single Path containing some (or none) wildcards ('*').
         Supports '**' for matching multiple directories.
         """
-
-        _cpp_parts = []
-        for obj in obj_files:
-            _cpp_parts.append(
-                _helios.read_obj_scene_part(
-                    str(obj), [str(p) for p in get_asset_directories()], up_axis
-                )
-            )
-
-        return [cls._from_cpp(part) for part in _cpp_parts]
+        return [ScenePart.from_obj(obj, up_axis) for obj in obj_files]
 
 
 class StaticScene(Model, cpp_class=_helios.StaticScene):

--- a/python/helios/utils.py
+++ b/python/helios/utils.py
@@ -53,7 +53,7 @@ def find_file(filename: Union[Path, str], fatal: bool = True) -> Union[Path, Non
     or in some default search locations.
 
     :param filename: The name of the file to find.
-    :type filename: str
+    :type filename: Union[Path, str]
     :param fatal: Whether to raise an exception if the file is not found.
     :type fatal: bool
     :return: The path to the file, or None if the file was not found.
@@ -61,7 +61,7 @@ def find_file(filename: Union[Path, str], fatal: bool = True) -> Union[Path, Non
     """
 
     # Convert the filename to a Path object if it is a string.
-    filename = Path(filename)
+    filename = Path(filename).expanduser()
 
     # Check if the given filename is an absolute path.
     if filename.is_absolute():
@@ -77,11 +77,48 @@ def find_file(filename: Union[Path, str], fatal: bool = True) -> Union[Path, Non
             return file_path
 
     if fatal:
+        m = f"Could not find file '{filename}' in any of the given asset directories."
+        if "*" in str(filename):
+            m += " For resolving wildcards, use 'find_files' instead of 'find_file'!"
+        raise FileNotFoundError(m)
+
+    return None
+
+
+def find_files(filename: Union[Path, str], fatal: bool = True) -> list[Path]:
+    """
+    Find files in the list of directories that have been added as asset directories
+    or in some default search locations. Supports wildcards in the search pattern.
+
+    :param filename: The name of the file to find.
+    :type filename: Union[Path, str]
+    :param fatal: Whether to raise an exception if no file is not found.
+    :type fatal: bool
+    :return: A list of found filepaths.
+    :rtype: list[Path]
+    """
+
+    filename = Path(filename).expanduser()
+    assets = get_asset_directories()
+    files = []
+
+    if filename.is_absolute():
+        if filename.exists():
+            return [filename]
+        else:
+            # resolve wildcards in absolut paths
+            parts = filename.parts
+            asset = parts[0]
+            filename = Path().joinpath(*parts[1:])
+
+    for asset in assets:
+        files.extend(asset.glob(str(filename)))
+
+    if len(files) == 0 and fatal:
         raise FileNotFoundError(
             f"Could not find file '{filename}' in any of the given asset directories."
         )
-
-    return None
+    return files
 
 
 @validate_call

--- a/python/helios/utils.py
+++ b/python/helios/utils.py
@@ -92,7 +92,7 @@ def find_files(filename: Union[Path, str], fatal: bool = True) -> list[Path]:
 
     :param filename: The name of the file to find.
     :type filename: Union[Path, str]
-    :param fatal: Whether to raise an exception if no file is not found.
+    :param fatal: Whether to raise an exception if no file is found.
     :type fatal: bool
     :return: A list of found filepaths.
     :rtype: list[Path]
@@ -106,9 +106,9 @@ def find_files(filename: Union[Path, str], fatal: bool = True) -> list[Path]:
         if filename.exists():
             return [filename]
         else:
-            # resolve wildcards in absolut paths
+            # resolve wildcards in absolute paths
             parts = filename.parts
-            asset = parts[0]
+            assets = [Path(parts[0])]
             filename = Path().joinpath(*parts[1:])
 
     for asset in assets:

--- a/python/helios/validation.py
+++ b/python/helios/validation.py
@@ -2,7 +2,7 @@ from helios.utils import find_file, find_files, is_real_iterable
 
 from collections.abc import Iterable
 from pathlib import Path
-from pydantic import validate_call, GetCoreSchemaHandler
+from pydantic import BeforeValidator, validate_call, GetCoreSchemaHandler
 from pydantic.functional_validators import AfterValidator
 from pydantic_core import core_schema
 from typing import Any, Optional, Type, Union, get_origin, get_args
@@ -50,7 +50,7 @@ def _create_directory(directory: Path):
 
 # Some type annotations for convenience
 AssetPath = Annotated[Path, AfterValidator(find_file)]
-MultiAssetPath = Annotated[Path, AfterValidator(find_files)]
+MultiAssetPath = Annotated[list[Path], BeforeValidator(find_files)]
 ThreadCount = Annotated[Optional[int], AfterValidator(_validate_thread_count)]
 CreatedDirectory = Annotated[Path, AfterValidator(_create_directory)]
 

--- a/python/helios/validation.py
+++ b/python/helios/validation.py
@@ -1,4 +1,4 @@
-from helios.utils import find_file, is_real_iterable
+from helios.utils import find_file, find_files, is_real_iterable
 
 from collections.abc import Iterable
 from pathlib import Path
@@ -50,6 +50,7 @@ def _create_directory(directory: Path):
 
 # Some type annotations for convenience
 AssetPath = Annotated[Path, AfterValidator(find_file)]
+MultiAssetPath = Annotated[Path, AfterValidator(find_files)]
 ThreadCount = Annotated[Optional[int], AfterValidator(_validate_thread_count)]
 CreatedDirectory = Annotated[Path, AfterValidator(_create_directory)]
 

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from helios.platforms import tripod as tripod_platform, sr22
 from helios.scanner import (
     leica_als50,
@@ -13,7 +15,7 @@ from helios.settings import (
     set_output_settings,
 )
 from helios.survey import Survey
-from helios.utils import set_rng_seed
+from helios.utils import add_asset_directory, set_rng_seed
 
 import math
 import pytest
@@ -107,3 +109,30 @@ def tls_survey(tls_scanner, tripod, scene):
 
 
 survey = tls_survey
+
+
+@pytest.fixture()
+def assetdir(tmp_path):
+    add_asset_directory(tmp_path)
+    tmp_path = tmp_path / "root"
+    tmp_path.mkdir()
+
+    a = tmp_path / "a"
+    b = tmp_path / "b" / "bb"
+    c = tmp_path / "c"
+    a.mkdir()
+    b.mkdir(parents=True)
+    c.mkdir()
+
+    a1 = a / "some.obj"
+    a2 = a / "second.obj"
+    a3 = a / "notobj.smth"
+    bb1 = b / "other.obj"
+    c1 = c / "notobj.smt"
+    a1.touch()
+    a2.touch()
+    a3.touch()
+    bb1.touch()
+    c1.touch()
+
+    return tmp_path

--- a/tests/python/test_scene.py
+++ b/tests/python/test_scene.py
@@ -42,6 +42,13 @@ def test_scenepart_from_obj():
     scene._finalize()
 
 
+def test_sceneparts_from_obj_wildcard():
+    box = ScenePart.from_objs("data/sceneparts/basic/**/*.obj")
+    assert len(box) == 4
+    scene = StaticScene(scene_parts=box)
+    scene._finalize()
+
+
 def test_scenepart_from_obj_yisup():
     box = ScenePart.from_obj("data/sceneparts/basic/box/box100.obj")
     scene = StaticScene(scene_parts=[box], up_axis="y")

--- a/tests/python/test_util.py
+++ b/tests/python/test_util.py
@@ -148,3 +148,6 @@ def test_find_files(assetdir):
 
     found = find_files("root/*/*.obj")
     assert len(found) == 2
+
+    found = find_files(assetdir / "*/*.obj")
+    assert len(found) == 2

--- a/tests/python/test_util.py
+++ b/tests/python/test_util.py
@@ -131,3 +131,20 @@ def test_combine_tuple_okay():
 def test_set_rng_seed():
     set_rng_seed(43)
     set_rng_seed(datetime.now(timezone.utc))
+
+
+def test_find_files(assetdir):
+    found = find_files("root/b/bb/other.obj")
+    assert len(found) == 1
+
+    found = find_files("root/b/*/other.obj")
+    assert len(found) == 1
+
+    found = find_files("root/a/*.obj")
+    assert len(found) == 2
+
+    found = find_files("root/**/*.obj")
+    assert len(found) == 3
+
+    found = find_files("root/*/*.obj")
+    assert len(found) == 2

--- a/tests/python/test_validation.py
+++ b/tests/python/test_validation.py
@@ -406,3 +406,14 @@ def test_created_directory_annotation(tmp_path):
 
     foo(tmp_path / "nonexistent")
     assert (tmp_path / "nonexistent").exists()
+
+
+def test_multiassetpath(assetdir):
+    assert (b := assetdir / "b" / "bb" / "other.obj").exists()
+
+    @validate_call
+    def from_obj(obj_file: MultiAssetPath):
+        return obj_file
+
+    # tmp_dir has different parents, because it gets called from different functions
+    assert b.parts[-4:] == from_obj("root/b/*/*.obj")[0].parts[-4:]


### PR DESCRIPTION
Parse asset paths containing wildcards. This is useful for loading multiple `.obj` files at once into multiple SceneParts.

Implements a new MultiAssetPath type. Only functions which want to use this feature need to switch from the unchanged AssetPath to the new MultiAssetPath.

This PR is based on the PR #572 branch

Fixes #557 