### PR TITLE
Implementation of laspy output

### DIFF
--- a/python/helios/survey.py
+++ b/python/helios/survey.py
@@ -173,7 +173,9 @@ class Survey(Model, cpp_class=_helios.Survey):
                 las = laspy.LasData(header)
                 las.synthetic = np.ones_like(las.synthetic)
 
-                las.x, las.y, las.z = np.unstack(data_mes["position"], axis=1)
+                las.x = data_mes["position"][:, 0]
+                las.y = data_mes["position"][:, 1]
+                las.z = data_mes["position"][:, 2]
                 las.intensity = data_mes["intensity"]
                 las.return_number = data_mes["return_number"]
                 las.number_of_returns = data_mes["pulse_return_number"]

--- a/python/helios/survey.py
+++ b/python/helios/survey.py
@@ -176,6 +176,7 @@ class Survey(Model, cpp_class=_helios.Survey):
                 las.x, las.y, las.z = np.unstack(data_mes["position"], axis=1)
                 las.intensity = data_mes["intensity"]
                 las.return_number = data_mes["return_number"]
+                las.number_of_returns = data_mes["pulse_return_number"]
                 las.gps_time = data_mes["gps_time"]
                 las.classification = data_mes["classification"]
                 las.echo_width = data_mes["echo_width"]

--- a/python/helios/survey.py
+++ b/python/helios/survey.py
@@ -169,6 +169,7 @@ class Survey(Model, cpp_class=_helios.Survey):
                         # laspy.ExtraBytesParams("hitObjectId", "U50"),
                     ]
                 )
+                header.generating_software = "HELIOS++"
 
                 las = laspy.LasData(header)
                 las.synthetic = np.ones_like(las.synthetic)

--- a/python/helios/survey.py
+++ b/python/helios/survey.py
@@ -19,6 +19,7 @@ from typing import Optional
 
 import numpy as np
 import tempfile
+import laspy
 
 import _helios
 
@@ -160,12 +161,6 @@ class Survey(Model, cpp_class=_helios.Survey):
                 return data_mes, data_traj
 
             if output_settings.format == OutputFormat.LASPY:
-                # raise NotImplementedError(
-                #     "LASPY output format is not yet supported, see https://github.com/3dgeo-heidelberg/helios/issues/561"
-                # )
-
-                import laspy
-
                 header = laspy.LasHeader(version="1.4", point_format=6)
                 header.add_extra_dims(
                     [

--- a/tests/python/test_survey.py
+++ b/tests/python/test_survey.py
@@ -81,8 +81,11 @@ def test_survey_run_xyz_output(survey, tmp_path):
 
 
 def test_survey_run_laspy_output(survey):
-    with pytest.raises(NotImplementedError):
-        survey.run(format=OutputFormat.LASPY)
+    las, traj = survey.run(format=OutputFormat.LASPY)
+
+    assert len(las.points) == 200
+    assert all(las.return_number == np.ones_like(las.return_number))
+    assert traj.shape == (101,)
 
 
 def test_set_gpstime(survey):


### PR DESCRIPTION
fixes #561

Takes the numpy output and translates it into a LasPy object.

Not all required fields of the [las specification](https://www.asprs.org/wp-content/uploads/2010/12/LAS_1_4_r13.pdf) are handed over from the C++ side, and are therefor absent in the output.
Currently, `Edge of flight line`, `scan angle`, `point source id`, `scan direction`, and `scanner channel` are missing.