### PR TITLE
Add preprocessor define required for running with GLM v1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ target_include_directories(helios
 # Expose version information to the C++ sources
 target_compile_definitions(helios
   PUBLIC
+    GLM_ENABLE_EXPERIMENTAL
     HELIOS_VERSION="${HELIOS_VERSION_FULL}"
     HELIOS_BUILD_TYPE="${CMAKE_BUILD_TYPE}"
 )


### PR DESCRIPTION
From my understanding, this does not require a bugfix release. The error is triggered by an `#error` directive at compile time, meaning that only users that compile Helios themselves are affected. Then however, these typically work with `main` and not the `v2.0.2` tag.

This fixes #612 