### PR TITLE
Add FullWaveformSettings to the Python API

### DIFF
--- a/python/helios/__init__.py
+++ b/python/helios/__init__.py
@@ -10,6 +10,7 @@ from helios.scanner import Scanner, ScannerSettings
 from helios.scene import StaticScene, ScenePart
 from helios.settings import (
     ExecutionSettings,
+    FullWaveformSettings,
     LogVerbosity,
     OutputSettings,
     ParallelizationStrategy,

--- a/python/helios/survey.py
+++ b/python/helios/survey.py
@@ -4,6 +4,7 @@ from helios.scanner import Scanner, ScannerSettings
 from helios.scene import StaticScene
 from helios.settings import (
     ExecutionSettings,
+    FullWaveformSettings,
     OutputFormat,
     OutputSettings,
     compose_execution_settings,
@@ -31,6 +32,7 @@ class Survey(Model, cpp_class=_helios.Survey):
     legs: list[Leg] = []
     name: str = ""
     gps_time: datetime = datetime.now(timezone.utc)
+    full_waveform_settings: FullWaveformSettings = FullWaveformSettings()
 
     @validate_call
     def run(
@@ -53,6 +55,11 @@ class Survey(Model, cpp_class=_helios.Survey):
         # Ensure that the scene has been finalized
         self.scene._finalize(execution_settings)
         self.scene._set_reflectances(self.scanner._cpp_object.wavelength)
+
+        # Set the fullwave form settings on the scanner
+        self.scanner._cpp_object.apply_settings_FWF(
+            self.full_waveform_settings._to_cpp()
+        )
 
         if output_settings.format in (OutputFormat.NPY, OutputFormat.LASPY):
             las_output, zip_output, export_to_file = False, False, False

--- a/tests/python/test_settings.py
+++ b/tests/python/test_settings.py
@@ -1,5 +1,7 @@
 from helios.settings import *
 
+from pathlib import Path
+
 
 def test_execution_settings_defaults():
     settings = ExecutionSettings()
@@ -73,3 +75,27 @@ def test_set_output_settings(reset_global_state):
     set_output_settings(write_pulse=True)
     assert compose_output_settings().format == OutputFormat.XYZ
     assert compose_output_settings().write_pulse == True
+
+
+def test_full_waveform_settings_defaults():
+    settings = FullWaveformSettings()
+
+    assert settings.bin_size == 2.5e-10
+    assert settings.beam_sample_quality == 3
+    assert settings.win_size == 1e-9
+    assert settings.max_fullwave_range == 0.0
+
+
+def test_convert_full_waveform_settings_to_cpp():
+    settings = FullWaveformSettings(
+        bin_size=1.0 * units.ns,
+        beam_sample_quality=4,
+        win_size=2.0 * units.ns,
+        max_fullwave_range=10.0 * units.ns,
+    )
+    cpp_settings = settings._to_cpp()
+
+    assert cpp_settings.bin_size == 1.0
+    assert cpp_settings.beam_sample_quality == 4
+    assert cpp_settings.win_size == 2.0
+    assert cpp_settings.max_fullwave_range == 10.0

--- a/tests/python/test_survey.py
+++ b/tests/python/test_survey.py
@@ -115,3 +115,14 @@ def test_survey_run_trajectory_for_all_scanner_types():
     points, trajectory = survey.run()
     assert points.shape[0] > 0
     assert trajectory.shape[0] > 0
+
+
+def test_full_waveform_settings_effect():
+    survey = Survey.from_xml("data/surveys/demo/light_als_toyblocks_multiscanner.xml")
+    points1, _ = survey.run(format=OutputFormat.NPY)
+
+    survey.full_waveform_settings.beam_sample_quality = 5
+    points2, _ = survey.run(format=OutputFormat.NPY)
+
+    # A higher beam sample quality should result in more points
+    assert points1.shape[0] < points2.shape[0]


### PR DESCRIPTION
This fixes #528.

Also, related to #610, it sets the default of the `win_size` parameter in the frontend to 1ns as discussed in person.