### PR TITLE
fix bug where output settings ignored in c++

### DIFF
--- a/python/helios/helios_python.cpp
+++ b/python/helios/helios_python.cpp
@@ -1484,7 +1484,6 @@ namespace helios{
 
             .def_property("pulse_freq_hz", &Scanner::getPulseFreq_Hz, &Scanner::setPulseFreq_Hz)    
             .def_property("is_state_active", &Scanner::isActive, &Scanner::setActive)
-            .def_property("write_wave_form", &Scanner::isWriteWaveform, &Scanner::setWriteWaveform)
             .def_property("calc_echowidth", &Scanner::isCalcEchowidth, &Scanner::setCalcEchowidth)
             .def_property("full_wave_noise", &Scanner::isFullWaveNoise, &Scanner::setFullWaveNoise)
             .def_property("platform_noise_disabled", &Scanner::isPlatformNoiseDisabled, &Scanner::setPlatformNoiseDisabled)
@@ -1531,8 +1530,16 @@ namespace helios{
                     }
                 },
                 "A shared mutex for synchronized operations"
-            );
-      
+            )
+            .def_property("write_waveform",
+                          &Scanner::isWriteWaveform,
+                          &Scanner::setWriteWaveform)
+            
+            .def_property("write_pulse",
+                            &Scanner::isWritePulse,
+                            &Scanner::setWritePulse);
+
+
 
         py::class_<PyHeliosSimulation> helios_simulation (m, "PyheliosSimulation");
         helios_simulation

--- a/python/helios/survey.py
+++ b/python/helios/survey.py
@@ -75,16 +75,20 @@ class Survey(Model, cpp_class=_helios.Survey):
                 "las": (True, False),
                 "xyz": (False, False),
             }.get(output_settings.format)
+
+            self.scanner._cpp_object.write_waveform = output_settings.write_waveform
+            self.scanner._cpp_object.write_pulse = output_settings.write_pulse
+
             fms = _helios.FMSFacadeFactory().build_facade(
                 str(output),
-                1.0,
+                output_settings.las_scale,
                 las_output,
                 False,
                 zip_output,
                 output_settings.split_by_channel,
                 self._cpp_object,
             )
-
+     
         # Set up internal data structures for the execution
 
         accuracy = self.scanner._cpp_object.detector.accuracy


### PR DESCRIPTION
This is a fix for Issue #619 .  Write_waveform, write_pulse and las_scale are now participate in c++ calculations