### PR TITLE
Add check excess args

### DIFF
--- a/python/helios/validation.py
+++ b/python/helios/validation.py
@@ -232,8 +232,8 @@ class ValidatedModelMetaClass(type):
 
                 # Raise an error if this was required and not we reached this point
                 raise ValueError(f"Missing required argument: {field}")
-            
-            instance_kwargs.pop("_cpp_object", None)  
+
+            instance_kwargs.pop("_cpp_object", None)
             invalid_fields = set(instance_kwargs) - set(annotations)
             if invalid_fields:
                 raise ValueError(f"Invalid fields passed: {', '.join(invalid_fields)}")

--- a/python/helios/validation.py
+++ b/python/helios/validation.py
@@ -232,6 +232,11 @@ class ValidatedModelMetaClass(type):
 
                 # Raise an error if this was required and not we reached this point
                 raise ValueError(f"Missing required argument: {field}")
+            
+            instance_kwargs.pop("_cpp_object", None)  
+            invalid_fields = set(instance_kwargs) - set(annotations)
+            if invalid_fields:
+                raise ValueError(f"Invalid fields passed: {', '.join(invalid_fields)}")
 
         setattr(cls, "__init__", __init__)
 

--- a/tests/python/test_scene.py
+++ b/tests/python/test_scene.py
@@ -57,8 +57,8 @@ def test_sceneparts_from_obj_wildcard():
 
 
 def test_scenepart_from_obj_yisup():
-    box = ScenePart.from_obj("data/sceneparts/basic/box/box100.obj")
-    scene = StaticScene(scene_parts=[box], up_axis="y")
+    box = ScenePart.from_obj("data/sceneparts/basic/box/box100.obj", up_axis="y")
+    scene = StaticScene(scene_parts=[box])
     scene._finalize()
 
 

--- a/tests/python/test_validation.py
+++ b/tests/python/test_validation.py
@@ -542,3 +542,11 @@ def test_model_hierarchy():
     assert z.x == 10
     assert z.y == 20
     assert z.z == 30
+
+
+def test_model_instantiated_with_invalid_fields():
+    class Obj(Model, cpp_class=MockCppObject):
+        someint: int = 41
+
+    with pytest.raises(ValueError):
+        Obj(unknown_field=100)


### PR DESCRIPTION
This is a fix for #644 . It is based on top of #649 for integrity, since since the `get_all_annotations` method is used from there.
Should be noted that it fixes original problem described in the error. It should be updated with patch, if necessary, described in comment to #644 .