### PR TITLE
Removed misleading logging of error message after intended behavior in WavefrontObj loading

### DIFF
--- a/src/assetloading/geometryfilter/WavefrontObjFileLoader.cpp
+++ b/src/assetloading/geometryfilter/WavefrontObjFileLoader.cpp
@@ -53,8 +53,7 @@ WavefrontObjFileLoader::run()
     ss << "Failed to read 'up'-axis from scene XML file.\n"
        << "Assuming 'z' axis points upwards for scene part \"" << filePathString
        << "\".\n"
-       << "Set up axis explicitly to silence this warning.\n"
-       << "C++ Exception: " << e.what();
+       << "Set up axis explicitly to silence this warning.\n";
     logging::INFO(ss.str());
   }
   // ######### END Read up axis ###########


### PR DESCRIPTION
When running the surveys, many examples (e.g. the demo surveys `als_interpolated_trajectory.xml` or `mls_wheat_demo.xml`) produce the following output during scene building:

`Failed to read 'up'-axis from scene XML file.
Assuming 'z' axis points upwards for scene part "".
Set up axis explicitly to silence this warning.
C++ Exception: boost::bad_get: failed value get using boost::get`

after the error message the scene building proceeds as intended.

This error message is caused in `WavefrontObjFileLoader.cpp`, where the "up" parameter is retrieved from the scene file in a try catch block. If no "up" value is set in the scene file, the up parameter is assumed as the z axis by default as stated. Additionally, the exception is printed, suggesting that the scene building failed, which is misleading since this seems like intended behavior.

Note: Since the error message occurs during scene building, the surveys need to be run with --rebuildScene to encounter the message in case the scene has already been built before.