### PR TITLE
update outdated  boost::io_service to  boost::asio::io_context

### DIFF
--- a/src/util/threadpool/MDThreadPool.h
+++ b/src/util/threadpool/MDThreadPool.h
@@ -2,7 +2,7 @@
 
 #include <HeliosException.h>
 #include <SimpleThreadPool.h>
-
+#include <boost/asio/post.hpp>
 #include <unordered_map>
 
 /**
@@ -53,7 +53,8 @@ public:
     lock.unlock();
 
     // Post a wrapped task into the queue
-    this->io_service_.post(
+    boost::asio::post(
+      this->io_context_,
       boost::bind(&MDThreadPool<MDType, TaskArgs...>::wrap_md_task,
                   this,
                   boost::function<void(TaskArgs...)>(task),
@@ -88,7 +89,8 @@ public:
     lock.unlock();
 
     // Post a wrapped task into the queue
-    this->io_service_.post(
+    boost::asio::post(
+      this->io_context_,
       boost::bind(&MDThreadPool<MDType, TaskArgs...>::wrap_md_task,
                   this,
                   boost::function<void(TaskArgs...)>(task),
@@ -105,7 +107,7 @@ public:
     while (getPendingTasks() > 0) {
       this->cond_.wait(lock);
     }
-    this->work_.reset();       // Allow works to finish normally
+    this->work_guard_.reset(); // Allow works to finish normally
     this->threads_.join_all(); // Wait for all threads to finish
   }
 

--- a/src/util/threadpool/ResThreadPool.h
+++ b/src/util/threadpool/ResThreadPool.h
@@ -2,7 +2,7 @@
 
 #include <HeliosException.h>
 #include <SimpleThreadPool.h>
-
+#include <boost/asio/post.hpp>
 /**
  * @verison 1.0
  * @brief Abstract class extending basic thread pool implementation to provide
@@ -88,11 +88,11 @@ public:
     lock.unlock();
 
     // Post a wrapped task into the queue
-    this->io_service_.post(
-      boost::bind(&ResThreadPool<TaskArgs...>::wrap_res_task,
-                  this,
-                  boost::function<void(TaskArgs...)>(task),
-                  resourceIdx));
+    boost::asio::post(this->io_context_,
+                      boost::bind(&ResThreadPool<TaskArgs...>::wrap_res_task,
+                                  this,
+                                  boost::function<void(TaskArgs...)>(task),
+                                  resourceIdx));
   }
 
   /**
@@ -124,11 +124,11 @@ public:
     lock.unlock();
 
     // Post a wrapped task into the queue
-    this->io_service_.post(
-      boost::bind(&ResThreadPool<TaskArgs...>::wrap_res_task,
-                  this,
-                  boost::function<void(TaskArgs...)>(task),
-                  resourceIdx));
+    boost::asio::post(this->io_context_,
+                      boost::bind(&ResThreadPool<TaskArgs...>::wrap_res_task,
+                                  this,
+                                  boost::function<void(TaskArgs...)>(task),
+                                  resourceIdx));
     return true;
   }
 

--- a/src/util/threadpool/SimpleThreadPool.h
+++ b/src/util/threadpool/SimpleThreadPool.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ThreadPool.h>
-
+#include <boost/asio/post.hpp>
 /**
  * @version 1.0
  * @brief Abstract class providing implementation of a simple thread pool which
@@ -12,7 +12,7 @@ template<typename... TaskArgs>
 class SimpleThreadPool : public ThreadPool
 {
 protected:
-  using ThreadPool::io_service_;
+  using ThreadPool::io_context_;
   using ThreadPool::pool_size;
   // ***  ATTRIBUTES  *** //
   // ******************** //
@@ -68,9 +68,10 @@ public:
     lock.unlock();
 
     // Post a wrapped task into the queue
-    io_service_.post(boost::bind(&SimpleThreadPool::wrap_task,
-                                 this,
-                                 boost::function<void(TaskArgs...)>(task)));
+    boost::asio::post(io_context_,
+                      boost::bind(&SimpleThreadPool::wrap_task,
+                                  this,
+                                  boost::function<void(TaskArgs...)>(task)));
   }
 
   /**

--- a/src/util/threadpool/WarehouseThreadPool.h
+++ b/src/util/threadpool/WarehouseThreadPool.h
@@ -18,7 +18,7 @@ template<typename Task>
 class WarehouseThreadPool : public ThreadPool
 {
 protected:
-  using ThreadPool::io_service_;
+  using ThreadPool::io_context_;
   using ThreadPool::pool_size;
   //  ***  ATTRIBUTES  *** //
   // ********************* //
@@ -136,7 +136,8 @@ public:
     // Start threads
     workersCount = pool_size;
     for (std::size_t tid = 0; tid < pool_size; ++tid) {
-      io_service_.post(boost::bind(&WarehouseThreadPool::_start, this, tid));
+      boost::asio::post(io_context_,
+                        boost::bind(&WarehouseThreadPool::_start, this, tid));
     }
   }
 


### PR DESCRIPTION
After some updates on the branch alpha-dev, there began to occur critical error during CI/CD because of deprecated  boost::asio::io_service. Change it to a newer boost::asio::io_context.