### PR TITLE
allow add scenePart to Scene

### DIFF
--- a/python/helios/helios_python.cpp
+++ b/python/helios/helios_python.cpp
@@ -3129,5 +3129,6 @@ PYBIND11_MODULE(_helios, m)
   m.def("read_scene_from_binary", &readSceneFromBinary);
   m.def("make_scene_shift", &makeSceneShift);
   m.def("load_interpolated_platform", &load_interpolated_platform);
+  m.def("add_scene_part_to_scene", &addScenePartToScene);
 }
 }

--- a/python/helios/scene.py
+++ b/python/helios/scene.py
@@ -288,8 +288,8 @@ class StaticScene(Model, cpp_class=_helios.StaticScene):
 
     def add_scene_part(self, scene_part: ScenePart):
         """Add a scene part to the scene."""
-
         self.scene_parts = self.scene_parts + (scene_part,)
+        _helios.add_scene_part_to_scene(self._cpp_object, scene_part._cpp_object)
 
     def _finalize(
         self, execution_settings: Optional[ExecutionSettings] = None, **parameters
@@ -316,6 +316,10 @@ class StaticScene(Model, cpp_class=_helios.StaticScene):
         )
 
     def _pre_set(self, field, value):
+        if is_xml_loaded(self) or is_binary_loaded(self):
+            raise RuntimeError(
+                "The scene loaded from XML cannot be modified."
+            )
         if field == "scene_parts":
             self._enforce_uniqueness_across_instances(field, value)
 

--- a/src/python/SceneHandling.cpp
+++ b/src/python/SceneHandling.cpp
@@ -440,3 +440,31 @@ makeSceneShift(Survey& survey)
     }
   }
 }
+
+void
+addScenePartToScene(std::shared_ptr<StaticScene> scene,
+                    std::shared_ptr<ScenePart> scenePart)
+{
+  invalidateStaticScene(scene);
+  scene->setKDGrove(nullptr);
+  for (auto& sp : scene->parts) {
+    // Append as a static object
+    scene->appendStaticObject(sp);
+
+    // Add scene part primitives to the scene
+    scene->primitives.insert(
+      scene->primitives.end(), sp->mPrimitives.begin(), sp->mPrimitives.end());
+  }
+  // Add the new scene part
+  for (Primitive* primitive : scenePart->mPrimitives) {
+    if (primitive->part == nullptr) {
+      primitive->part = scenePart;
+    }
+  }
+  scene->appendStaticObject(scenePart);
+  scene->primitives.insert(scene->primitives.end(),
+                           scenePart->mPrimitives.begin(),
+                           scenePart->mPrimitives.end());
+  scene->registerParts();
+  invalidateStaticScene(scene); // invalidate it for further finalization
+}

--- a/src/python/SceneHandling.h
+++ b/src/python/SceneHandling.h
@@ -79,3 +79,7 @@ findNonDefaultScannerSettings(std::shared_ptr<ScannerSettings> base,
 
 void
 makeSceneShift(Survey& survey);
+
+void
+addScenePartToScene(std::shared_ptr<StaticScene> scene,
+                    std::shared_ptr<ScenePart> scenePart);


### PR DESCRIPTION
A function to let users add SceneParts to manually constructed Scene.  It fixes Issue #685 for this type of Scenes. Also it prohibits changing Scenes, that were loaded via from_XML or from_binary