### PR TITLE
make laz the new default output format for the CLI

### DIFF
--- a/python/helios/__main__.py
+++ b/python/helios/__main__.py
@@ -63,7 +63,7 @@ from helios.utils import add_asset_directory, set_rng_seed
 )
 @optgroup.option(
     "--format",
-    default="npy",
+    default="laz",
     show_default=True,
     help="Output format, can be las, laz, xyz, npy, or laspy.",
 )


### PR DESCRIPTION
Bugfix: It does not make sense to have "npy" as default for the command line mode, because then the user will not get any output at all. Although our previous default output format was "txt", I would advocate for making "laz" the new default (smallest file size, fastest to write, industry standard).