### PR TITLE
add leg_id to point clouds

### DIFF
--- a/python/helios/utils.py
+++ b/python/helios/utils.py
@@ -301,6 +301,7 @@ meas_dtype = np.dtype(
         ("fullwave_index", "i4"),
         ("classification", "i4"),
         ("gps_time", "f8"),
+        ("point_source_id", "u2"),
     ]
 )
 

--- a/src/python/NumpyArrayConversion.h
+++ b/src/python/NumpyArrayConversion.h
@@ -67,6 +67,7 @@ measurements_to_numpy(const std::vector<Measurement>& measurements)
   meas_fields.append(py::make_tuple("fullwave_index", "i4"));
   meas_fields.append(py::make_tuple("classification", "i4"));
   meas_fields.append(py::make_tuple("gps_time", "f8"));
+  meas_fields.append(py::make_tuple("point_source_id", "u2"));
 
   py::object dtype = np.attr("dtype")(meas_fields);
   py::dict fields = dtype.attr("fields");
@@ -98,6 +99,7 @@ measurements_to_numpy(const std::vector<Measurement>& measurements)
   size_t off_full = offsets["fullwave_index"];
   size_t off_class = offsets["classification"];
   size_t off_time = offsets["gps_time"];
+  size_t off_current_leg_index = offsets["point_source_id"];
 
   std::array<char32_t, 50> utf32_buffer;
 
@@ -122,6 +124,8 @@ measurements_to_numpy(const std::vector<Measurement>& measurements)
     *reinterpret_cast<int32_t*>(row + off_full) = m.fullwaveIndex;
     *reinterpret_cast<int32_t*>(row + off_class) = m.classification;
     *reinterpret_cast<double*>(row + off_time) = m.gpsTime / 1e9;
+    *reinterpret_cast<uint16_t*>(row + off_current_leg_index) =
+      m.currentLegIndex;
   }
 
   return result;

--- a/src/scanner/Measurement.h
+++ b/src/scanner/Measurement.h
@@ -72,6 +72,10 @@ public:
    * @brief Measurement GPS time
    */
   double gpsTime;
+  /**
+   * @brief Current leg index (only for point cloud output in Python API)
+   */
+  uint16_t currentLegIndex = 65535; // Default to 65535 indicating undefined
 
   // ***  CONSTRUCTION / DESTRUCTION  *** //
   // ************************************ //
@@ -95,6 +99,7 @@ public:
     fullwaveIndex = m.fullwaveIndex;
     classification = m.classification;
     gpsTime = m.gpsTime;
+    currentLegIndex = m.currentLegIndex;
   }
   virtual ~Measurement() = default;
 

--- a/src/scanner/detector/FullWaveformPulseRunnable.cpp
+++ b/src/scanner/detector/FullWaveformPulseRunnable.cpp
@@ -579,6 +579,7 @@ FullWaveformPulseRunnable::digestFullWaveform(
     tmp.returnNumber = numReturns + 1;
     tmp.classification = classification;
     tmp.gpsTime = pulse.getTime();
+    tmp.currentLegIndex = pulse.getLegIndex();
 
     pointsMeasurement.push_back(tmp);
     ++numReturns;


### PR DESCRIPTION
This is a fix for Issue #707 . Added leg_id for each point from a cloud as a "point_source_id".