### PR TITLE
fix the construction of the kd-tree to eliminate failure in rare cases.

### DIFF
--- a/python/helios/scene.py
+++ b/python/helios/scene.py
@@ -149,7 +149,9 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
     def from_tiff(cls, tiff_file: AssetPath):
         """Load the scene part from a TIFF file."""
 
-        _cpp_part = _helios.read_tiff_scene_part(str(tiff_file))
+        _cpp_part = _helios.read_tiff_scene_part(
+            str(tiff_file), [str(p) for p in get_asset_directories()]
+        )
 
         return cls._from_cpp(_cpp_part)
 

--- a/src/python/SceneHandling.cpp
+++ b/src/python/SceneHandling.cpp
@@ -61,15 +61,12 @@ finalizeStaticScene(std::shared_ptr<StaticScene> scene,
       scene->primitives.end(), sp->mPrimitives.begin(), sp->mPrimitives.end());
   }
 
+  scene->setKDGroveFactory(std::make_shared<KDGroveFactory>(makeKDTreeFactory(
+    kdtFactoryType, kdtNumJobs, kdtGeomJobs, kdtSAHLossNodes)));
   // Call scene finalization
   if (!scene->finalizeLoading()) {
     throw std::runtime_error("Finalizing the scene failed.");
   }
-
-  // Build KDGroveFactory
-  scene->setKDGroveFactory(std::make_shared<KDGroveFactory>(makeKDTreeFactory(
-    kdtFactoryType, kdtNumJobs, kdtGeomJobs, kdtSAHLossNodes)));
-  scene->buildKDGroveWithLog();
 }
 
 void
@@ -114,11 +111,12 @@ readObjScenePart(std::string filePath,
 }
 
 std::shared_ptr<ScenePart>
-readTiffScenePart(std::string filePath)
+readTiffScenePart(std::string filePath, std::vector<std::string> assetsPath)
 {
 
   GeoTiffFileLoader loader;
   loader.params["filepath"] = filePath;
+  loader.setAssetsDir(assetsPath);
   std::shared_ptr<ScenePart> sp(loader.run());
 
   // Connect all primitives to their scene part

--- a/src/python/SceneHandling.h
+++ b/src/python/SceneHandling.h
@@ -24,7 +24,7 @@ readObjScenePart(std::string filePath,
                  std::string upaxis);
 
 std::shared_ptr<ScenePart>
-readTiffScenePart(std::string filePath);
+readTiffScenePart(std::string filePath, std::vector<std::string> assetsPath);
 
 std::shared_ptr<ScenePart>
 readXYZScenePart(


### PR DESCRIPTION
Add fix for Issue #699 . This happened because, in some cases, Scene.kdgf had not yet been correctly constructed, but was required for KDTree calculations.