### PR TITLE
fix some cases of freezing in jupyter

### DIFF
--- a/python/helios/helios_python.cpp
+++ b/python/helios/helios_python.cpp
@@ -2721,7 +2721,7 @@ PYBIND11_MODULE(_helios, m)
                   &Simulation::getCallbackFrequency,
                   &Simulation::setCallbackFrequency)
 
-    .def("start", &Simulation::start)
+    .def("start", &Simulation::start, py::call_guard<py::gil_scoped_release>())
     .def("pause", &Simulation::pause)
     .def("stop", &Simulation::stop);
 


### PR DESCRIPTION
Sometimes I encountered the following problem: when running a Python script through the terminal, calculations were very fast, but if I ran the same code through Jupyter Notebook, it could take much longer, and sometimes even freeze. This small fix should solve the problem. 