### PR TITLE
add some description and throw meaningful errors for shape of trajectory array

### DIFF
--- a/python/helios/platforms.py
+++ b/python/helios/platforms.py
@@ -1,5 +1,5 @@
 from helios.scene import StaticScene
-from helios.utils import get_asset_directories
+from helios.utils import get_asset_directories, _validate_trajectory_array
 from helios.validation import (
     AssetPath,
     Model,
@@ -156,10 +156,19 @@ class Platform(Printable, Model, cpp_class=_helios.Platform):
         interpolation_method: Literal["CANONICAL", "ARINC 705"] = "ARINC 705",
         sync_gps_time: bool = False,
     ):
-        """Load a platform from an XML file with interpolation enabled."""
+        """Load a platform from an XML file with interpolation enabled.
+        Args:
+            trajectory: 1-D structured NumPy array of shape (n,).
+            platform_file: File path to platform XML file.
+            platform_id: ID of desired platform.
+            interpolation_method: Interpolation method to use. Options are "CANONICAL" and "ARINC 705".
+            sync_gps_time: Whether to sync GPS time with platform's start time.
+        """
 
         # Validate the XML
         validate_xml_file(platform_file, "xsd/platform.xsd")
+
+        _validate_trajectory_array(trajectory)
 
         _cpp_platform = _helios.read_platform_from_xml(
             str(platform_file), [str(p) for p in get_asset_directories()], platform_id

--- a/python/helios/utils.py
+++ b/python/helios/utils.py
@@ -254,6 +254,24 @@ def detect_separator(file_path: Path) -> str:
     raise ValueError(f"Could not detect separator in file: {file_path}")
 
 
+def _validate_trajectory_array(trajectory: np.ndarray) -> None:
+    """Validate that the trajectory array has the correct dtype and shape."""
+    if not isinstance(trajectory, np.ndarray):
+        raise TypeError(
+            f"Trajectory must be a NumPy ndarray. Got {type(trajectory)!r}."
+        )
+
+    if trajectory.ndim != 1:
+        raise ValueError(
+            f"Trajectory array must be 1-dimensional np.ndarray. Got {trajectory.ndim} dimensions."
+        )
+
+    if trajectory.dtype.names is None:
+        raise ValueError(
+            "Trajectory must be a structured NumPy array with named fields."
+        )
+
+
 def is_finalized(obj) -> bool:
     """Return True if the Scene was finalized."""
     return getattr(obj, "_is_finalized", False)

--- a/src/python/InterpolatedPlatformPreparation.cpp
+++ b/src/python/InterpolatedPlatformPreparation.cpp
@@ -13,7 +13,8 @@ load_interpolated_platform(std::shared_ptr<LinearPathPlatform> basePlatform,
   // Acquire buffer
   auto buf = trajectory.request();
   if (buf.ndim != 1)
-    throw std::runtime_error("Trajectory array must be 1-dimensional");
+    throw std::runtime_error(
+      "Trajectory must be a 1-D structured NumPy array (shape=(n,).");
 
   // shape = (m,), each item is a struct of n doubles
   size_t m = buf.shape[0];

--- a/tests/python/test_platform.py
+++ b/tests/python/test_platform.py
@@ -111,6 +111,42 @@ def test_load_interpolate_platform_invalid_id():
         )
 
 
+def test_load_interpolate_platform_invalid_trajectory():
+    trajectory1 = np.zeros((2, 7), dtype=traj_csv_dtype)
+    with pytest.raises(ValueError):
+        Platform.load_interpolate_platform(
+            trajectory=trajectory1,
+            platform_file="data/platforms.xml",
+            platform_id="sr22",
+        )
+
+    trajectory2 = np.zeros((51, 7, 2))
+    with pytest.raises(ValueError):
+        ip = Platform.load_interpolate_platform(
+            trajectory=trajectory2,
+            platform_file="data/platforms.xml",
+            platform_id="sr22",
+        )
+
+    trajectory3 = list(range(51))
+    with pytest.raises(ValueError):
+        ip = Platform.load_interpolate_platform(
+            trajectory=trajectory3,
+            platform_file="data/platforms.xml",
+            platform_id="sr22",
+        )
+    trajectory4 = np.array(
+        [3.7, -1.04719755, 1.04719755, 5.77180384, 13.002584, 1.122905, 400.0]
+    )
+
+    with pytest.raises(ValueError):
+        ip = Platform.load_interpolate_platform(
+            trajectory=trajectory4,
+            platform_file="data/platforms.xml",
+            platform_id="sr22",
+        )
+
+
 def test_load_interpolate_platform():
     trajectory = load_traj_csv(
         csv="data/trajectories/cycloid.trj",
@@ -129,16 +165,6 @@ def test_load_interpolate_platform():
     )
 
     assert isinstance(ip, Platform)
-
-
-def test_load_interpolate_platform_wrong_trajectory_shape():
-    trajectory = np.zeros((2, 7), dtype=traj_csv_dtype)
-    with pytest.raises(RuntimeError):
-        Platform.load_interpolate_platform(
-            trajectory=trajectory,
-            platform_file="data/platforms.xml",
-            platform_id="sr22",
-        )
 
 
 def test_load_interpolate_platform_wrong_rotation_spec():


### PR DESCRIPTION
Add some description and throw meaningful errors for the np.ndarray trajectory  during InterpolatedPlatform  loading process, as described in Issue #714. 