### PR TITLE
change default scan angle to 0 to have a  valid values from scanner

### DIFF
--- a/python/helios/scanner.py
+++ b/python/helios/scanner.py
@@ -27,7 +27,7 @@ class ScannerSettings(ScannerSettingsBase):
     rotation_start_angle: Angle = 0
     rotation_stop_angle: Angle = 0
     pulse_frequency: Frequency = 300000
-    scan_angle: Angle = 0.349066
+    scan_angle: Angle = 0
     min_vertical_angle: Angle = np.nan
     max_vertical_angle: Angle = np.nan
     scan_frequency: Frequency = 200

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -98,6 +98,7 @@ def tls_survey(tls_scanner, tripod, scene):
         y=0,
         z=0,
         pulse_frequency=2000,
+        scan_angle="20 deg",
         head_rotation="10 deg/s",
         rotation_start_angle="0 deg",
         rotation_stop_angle="10 deg",


### PR DESCRIPTION
This change allows the API to achieve the expected behavior described in the Issue #716 .