### PR TITLE
Expose bbox on Scene and SceneParts

### DIFF
--- a/python/helios/__init__.py
+++ b/python/helios/__init__.py
@@ -16,7 +16,7 @@ from helios.platforms import (
     platform_from_name,
 )
 from helios.scanner import Scanner, ScannerSettings, list_scanners, scanner_from_name
-from helios.scene import StaticScene, ScenePart
+from helios.scene import StaticScene, ScenePart, BoundingBox
 from helios.settings import (
     ExecutionSettings,
     ForceOnGroundStrategy,

--- a/python/helios/validation.py
+++ b/python/helios/validation.py
@@ -127,6 +127,8 @@ def _is_iterable_of_model_annotation(a):
         return False
 
     args = get_args(a)
+    if len(args) == 0 or not isinstance(args[0], type):
+        return False
     return issubclass(args[0], Model)
 
 
@@ -224,6 +226,12 @@ class ValidatedModelMetaClass(type):
                             )
                     else:
                         if hasattr(a, "_cpp_class"):
+                            if not hasattr(self, f"_{f}"):
+                                if hasattr(a, "_from_cpp"):
+                                    setattr(self, f"_{f}", a._from_cpp(value))
+                                    return getattr(self, f"_{f}")
+                                setattr(self, f"_{f}", value)
+                                return value
                             getattr(self, f"_{f}")._cpp_object = value
                             return getattr(self, f"_{f}")
                         return value

--- a/src/python/SceneHandling.cpp
+++ b/src/python/SceneHandling.cpp
@@ -242,6 +242,7 @@ rotateScenePart(std::shared_ptr<ScenePart> sp, Rotation rotation)
 {
   for (auto p : sp->mPrimitives)
     p->rotate(rotation);
+  sp->bound = nullptr;
 }
 
 void
@@ -249,6 +250,7 @@ scaleScenePart(std::shared_ptr<ScenePart> sp, double scaleFactor)
 {
   for (auto p : sp->mPrimitives)
     p->scale(scaleFactor);
+  sp->bound = nullptr;
 }
 
 void
@@ -256,6 +258,7 @@ translateScenePart(std::shared_ptr<ScenePart> sp, glm::dvec3 offset)
 {
   for (auto p : sp->mPrimitives)
     p->translate(offset);
+  sp->bound = nullptr;
 }
 
 void


### PR DESCRIPTION
In the process, we are also adjusting the Model base class to allow readonly properties that are not taken as input parameters, but can only be used in readonly fashion.