### PR TITLE
placed back previous functionality and changed order in getAngles

### DIFF
--- a/src/maths/Directions.cpp
+++ b/src/maths/Directions.cpp
@@ -3,6 +3,12 @@
 
 // ***  CONSTANTS  *** //
 // ******************* //
+// Canonical basis
 const glm::dvec3 Directions::right = glm::dvec3(1, 0, 0);
 const glm::dvec3 Directions::forward = glm::dvec3(0, 1, 0);
 const glm::dvec3 Directions::up = glm::dvec3(0, 0, 1);
+
+// ARINC 705 norm
+const glm::dvec3 Directions::yaw = glm::dvec3(0, 0, -1);
+const glm::dvec3 Directions::roll = glm::dvec3(0, 1, 0);
+const glm::dvec3 Directions::pitch = glm::dvec3(1, 0, 0);

--- a/src/platform/InterpolatedMovingPlatform.cpp
+++ b/src/platform/InterpolatedMovingPlatform.cpp
@@ -45,18 +45,16 @@ InterpolatedMovingPlatform::InterpolatedMovingPlatform(
       break;
     case RotationSpec::ARINC_705:
       calcAttitude = [](arma::Col<double> const x) -> Rotation {
-        return Rotation(Directions::right, -x[0])
-          .applyTo(Rotation(Directions::forward, -x[1]))
-          .applyTo(Rotation(Directions::up, -x[2]));
+        return Rotation(Directions::yaw, x[2])
+          .applyTo(Rotation(Directions::roll, x[0]))
+          .applyTo(Rotation(Directions::pitch, x[1]));
       };
       _getRollPitchYaw = [](double& roll,
                             double& pitch,
                             double& yaw,
                             Rotation& attitude) -> void {
-        attitude.getAngles(&RotationOrder::XYZ, roll, pitch, yaw);
-        roll = -roll;
-        pitch = -pitch;
-        yaw = -yaw;
+        attitude.getAngles(&RotationOrder::ZYX, yaw, roll, pitch);
+        yaw = (yaw < M_PI) ? -yaw : PI_2 - yaw;
       };
       break;
     default:


### PR DESCRIPTION
This PR should fix Issue #769 .
It restores the functionality related to `ARINC_705` to the state prior to #453 and it's fix.
There is also one small change in the order in `getAngles(...)` that should fix #453.

I think that this commit requires thorough testing from a scientific POV, including usage of real-life examples (if possible).
