### PR TITLE
Remove exception registration conflicting with pybind11 global registry

### DIFF
--- a/python/helios/helios_python.cpp
+++ b/python/helios/helios_python.cpp
@@ -193,11 +193,6 @@ PYBIND11_MODULE(_helios, m)
 
   py::implicitly_convertible<py::iterable, VectorString>();
   py::register_exception<HeliosException>(m, "HeliosException");
-  py::register_exception<std::out_of_range>(m, "IndexError", PyExc_IndexError);
-  py::register_exception<std::invalid_argument>(
-    m, "ValueError", PyExc_ValueError);
-  py::register_exception<std::runtime_error>(
-    m, "RuntimeError", PyExc_RuntimeError);
 
   // Enable GDAL (Load its drivers)
   GDALAllRegister();


### PR DESCRIPTION
There was a report of this brekaing downstream code. Also, the idea behind them was "only" slightly improved user output, so we can just remove them.