### PR TITLE
Vertical angle limit fix

### DIFF
--- a/src/scanner/beamDeflector/PolygonMirrorBeamDeflector.cpp
+++ b/src/scanner/beamDeflector/PolygonMirrorBeamDeflector.cpp
@@ -49,8 +49,10 @@ PolygonMirrorBeamDeflector::applySettings(
 
   std::stringstream ss;
   ss << "Applying settings for PolygonMirrorBeamDeflector...\n";
-  ss << "Vertical angle min/max " << MathConverter::radiansToDegrees(cfg_setting_verticalAngleMin_rad) << "/"
-     << MathConverter::radiansToDegrees(cfg_setting_verticalAngleMax_rad) << " degrees";
+  ss << "Vertical angle min/max "
+     << MathConverter::radiansToDegrees(cfg_setting_verticalAngleMin_rad) << "/"
+     << MathConverter::radiansToDegrees(cfg_setting_verticalAngleMax_rad)
+     << " degrees";
 
   // if not set, use the ones from the scanAngleEffectiveMax or scanAngle
   // (whichever is lower)
@@ -70,16 +72,19 @@ PolygonMirrorBeamDeflector::applySettings(
        << " degrees";
   }
 
-  // ensure that the range between min and max vertical angle is not bigger than the effective scan angle
+  // ensure that the range between min and max vertical angle is not bigger than
+  // the effective scan angle
   double verticalAngleRange_rad =
     cfg_setting_verticalAngleMax_rad - cfg_setting_verticalAngleMin_rad;
-  if (verticalAngleRange_rad > cfg_device_scanAngleEffectiveMax_rad*2) {
+  if (verticalAngleRange_rad > cfg_device_scanAngleEffectiveMax_rad * 2) {
     // rase an error and exit
     std::stringstream ss;
     ss << "Error: The range between verticalAngleMin and verticalAngleMax ("
        << MathConverter::radiansToDegrees(verticalAngleRange_rad)
-       << " degrees) cannot be bigger than the effective maximum scan angle (scanAngleEffectiveMax) of the device ("
-       << MathConverter::radiansToDegrees(cfg_device_scanAngleEffectiveMax_rad*2)
+       << " degrees) cannot be bigger than the effective maximum scan angle "
+          "(scanAngleEffectiveMax) of the device ("
+       << MathConverter::radiansToDegrees(cfg_device_scanAngleEffectiveMax_rad *
+                                          2)
        << " degrees). Please adjust the settings.";
     logging::ERR(ss.str());
     throw HeliosException(ss.str());

--- a/src/scanner/beamDeflector/PolygonMirrorBeamDeflector.cpp
+++ b/src/scanner/beamDeflector/PolygonMirrorBeamDeflector.cpp
@@ -1,6 +1,6 @@
 #include "PolygonMirrorBeamDeflector.h"
-#include <HeliosException.h>
 #include "maths/Directions.h"
+#include <HeliosException.h>
 #include <iostream>
 #include <logging.hpp>
 #include <sstream>

--- a/src/scanner/beamDeflector/PolygonMirrorBeamDeflector.cpp
+++ b/src/scanner/beamDeflector/PolygonMirrorBeamDeflector.cpp
@@ -49,8 +49,8 @@ PolygonMirrorBeamDeflector::applySettings(
 
   std::stringstream ss;
   ss << "Applying settings for PolygonMirrorBeamDeflector...\n";
-  ss << "Vertical angle min/max " << cfg_setting_verticalAngleMin_rad << "/"
-     << cfg_setting_verticalAngleMax_rad;
+  ss << "Vertical angle min/max " << MathConverter::radiansToDegrees(cfg_setting_verticalAngleMin_rad) << "/"
+     << MathConverter::radiansToDegrees(cfg_setting_verticalAngleMax_rad) << " degrees";
 
   // if not set, use the ones from the scanAngleEffectiveMax or scanAngle
   // (whichever is lower)
@@ -68,6 +68,21 @@ PolygonMirrorBeamDeflector::applySettings(
     ss << "\n -- verticalAngleMax not set, using the value of "
        << MathConverter::radiansToDegrees(cfg_setting_verticalAngleMax_rad)
        << " degrees";
+  }
+
+  // ensure that the range between min and max vertical angle is not bigger than the effective scan angle
+  double verticalAngleRange_rad =
+    cfg_setting_verticalAngleMax_rad - cfg_setting_verticalAngleMin_rad;
+  if (verticalAngleRange_rad > cfg_device_scanAngleEffectiveMax_rad*2) {
+    // rase an error and exit
+    std::stringstream ss;
+    ss << "Error: The range between verticalAngleMin and verticalAngleMax ("
+       << MathConverter::radiansToDegrees(verticalAngleRange_rad)
+       << " degrees) cannot be bigger than the effective maximum scan angle (scanAngleEffectiveMax) of the device ("
+       << MathConverter::radiansToDegrees(cfg_device_scanAngleEffectiveMax_rad*2)
+       << " degrees). Please adjust the settings.";
+    logging::ERR(ss.str());
+    exit(1);
   }
   state_currentBeamAngle_rad = 0;
   logging::INFO(ss.str());
@@ -100,17 +115,11 @@ PolygonMirrorBeamDeflector::doSimStep()
 bool
 PolygonMirrorBeamDeflector::lastPulseLeftDevice()
 {
-  // four conditions for the beam to return an echo:
-  // 1) abs(currentAngle) <= scanAngleEffectiveMax
-  // 2) abs(currentAngle) <= scanAngle (if it is set to something smaller)
-  // 3) currentAngle > verticalAngleMin
-  // 4) currentAngle <= verticalAngleMax
+  // two conditions for the beam to return an echo:
+  // 1) currentAngle > verticalAngleMin
+  // 2) currentAngle <= verticalAngleMax
 
-  return std::fabs(this->state_currentBeamAngle_rad) <=
-           this->cfg_device_scanAngleEffectiveMax_rad &&
-         std::fabs(this->state_currentBeamAngle_rad) <=
-           this->cfg_setting_scanAngle_rad &&
-         this->state_currentBeamAngle_rad >
+  return this->state_currentBeamAngle_rad >
            this->cfg_setting_verticalAngleMin_rad &&
          this->state_currentBeamAngle_rad <=
            this->cfg_setting_verticalAngleMax_rad;

--- a/src/scanner/beamDeflector/PolygonMirrorBeamDeflector.cpp
+++ b/src/scanner/beamDeflector/PolygonMirrorBeamDeflector.cpp
@@ -82,7 +82,7 @@ PolygonMirrorBeamDeflector::applySettings(
        << MathConverter::radiansToDegrees(cfg_device_scanAngleEffectiveMax_rad*2)
        << " degrees). Please adjust the settings.";
     logging::ERR(ss.str());
-    exit(1);
+    throw HeliosException(ss.str());
   }
   state_currentBeamAngle_rad = 0;
   logging::INFO(ss.str());

--- a/src/scanner/beamDeflector/PolygonMirrorBeamDeflector.cpp
+++ b/src/scanner/beamDeflector/PolygonMirrorBeamDeflector.cpp
@@ -1,5 +1,5 @@
 #include "PolygonMirrorBeamDeflector.h"
-
+#include <HeliosException.h>
 #include "maths/Directions.h"
 #include <iostream>
 #include <logging.hpp>

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -88,7 +88,12 @@ def box(box_f):
 
 @pytest.fixture
 def wall_f():
-    return lambda: ScenePart.from_obj("data/sceneparts/basic/plane/plane.obj").scale(200).rotate(angle=90 * helios.units.deg, axis=(1, 0, 0)).translate([0, 50, 0])
+    return (
+        lambda: ScenePart.from_obj("data/sceneparts/basic/plane/plane.obj")
+        .scale(200)
+        .rotate(angle=90 * helios.units.deg, axis=(1, 0, 0))
+        .translate([0, 50, 0])
+    )
 
 
 @pytest.fixture

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import helios
 from helios.platforms import tripod as tripod_platform, sr22
 from helios.scanner import (
     leica_als50,
@@ -86,8 +87,23 @@ def box(box_f):
 
 
 @pytest.fixture
+def wall_f():
+    return lambda: ScenePart.from_obj("data/sceneparts/basic/plane/plane.obj").scale(200).rotate(angle=90 * helios.units.deg, axis=(1, 0, 0)).translate([0, 50, 0])
+
+
+@pytest.fixture
+def wall(wall_f):
+    return wall_f()
+
+
+@pytest.fixture
 def scene(box):
     return StaticScene(scene_parts=[box])
+
+
+@pytest.fixture
+def wall_scene(wall):
+    return StaticScene(scene_parts=[wall])
 
 
 @pytest.fixture

--- a/tests/python/test_survey.py
+++ b/tests/python/test_survey.py
@@ -13,6 +13,7 @@ from helios.scene import StaticScene, ScenePart
 from helios.settings import ExecutionSettings
 from helios.survey import *
 from helios.utils import set_rng_seed
+from helios import HeliosException
 
 import copy
 import laspy
@@ -657,6 +658,5 @@ def test_survey_run_with_invalid_vert_angle_limits(scene):
         rotation_stop_angle="1 deg",
     )
 
-    # TODO: Do we need to add the check whether the range of vertical angle limits is larger than the effective max scan angle in the Python code as well?
-    with pytest.raises(RuntimeError):
+    with pytest.raises(HeliosException):
         survey.run(format=OutputFormat.NPY)

--- a/tests/python/test_survey.py
+++ b/tests/python/test_survey.py
@@ -595,7 +595,9 @@ def test_survey_run_with_hor_ver_resolution(scene):
     assert trajectory.shape[0] > 0
 
 
-def test_survey_run_with_non_symmetric_vert_angle_limits_and_max_larger_than_effective_max_scan_angle(wall_scene):
+def test_survey_run_with_non_symmetric_vert_angle_limits_and_max_larger_than_effective_max_scan_angle(
+    wall_scene,
+):
     """
     Test that the simulated output has the correct extent when vertical angle limits are not symmetric around zero
     and the max vertical angle is larger than the effecte max scan angle.

--- a/tests/python/test_survey.py
+++ b/tests/python/test_survey.py
@@ -593,3 +593,68 @@ def test_survey_run_with_hor_ver_resolution(scene):
 
     assert points.shape[0] > 0
     assert trajectory.shape[0] > 0
+
+
+def test_survey_run_with_non_symmetric_vert_angle_limits_and_max_larger_than_effective_max_scan_angle(wall_scene):
+    """
+    Test that the simulated output has the correct extent when vertical angle limits are not symmetric around zero
+    and the max vertical angle is larger than the effecte max scan angle.
+    """
+    scanner_settings = ScannerSettings(
+        pulse_frequency=300_000,
+        vertical_resolution="0.05 deg",
+        horizontal_resolution="0.05 deg",
+        min_vertical_angle="-40 deg",
+        max_vertical_angle="60 deg",
+    )
+
+    scanner = riegl_vz_400()
+    platform = tripod()
+
+    survey = Survey(scanner=scanner, platform=platform, scene=wall_scene)
+
+    survey.add_leg(
+        scanner_settings=scanner_settings,
+        x=0.0,
+        y=0.0,
+        z=-1.7,
+        rotation_start_angle="-1 deg",
+        rotation_stop_angle="1 deg",
+    )
+
+    points, _ = survey.run(format=OutputFormat.NPY)
+
+    eps = 0.1
+    assert abs(np.max(points["position"][:, 2]) - 86.6) < eps
+    assert abs(np.min(points["position"][:, 2]) - (-41.95)) < eps
+
+
+def test_survey_run_with_invalid_vert_angle_limits(scene):
+    """
+    Test that an error is raised if the range of vertical angle limits is larger than the effective max scan angle of the device.
+    """
+    scanner_settings = ScannerSettings(
+        pulse_frequency=300_000,
+        vertical_resolution="0.05 deg",
+        horizontal_resolution="0.05 deg",
+        min_vertical_angle="-50 deg",
+        max_vertical_angle="60 deg",
+    )
+
+    scanner = riegl_vz_400()
+    platform = tripod()
+
+    survey = Survey(scanner=scanner, platform=platform, scene=scene)
+
+    survey.add_leg(
+        scanner_settings=scanner_settings,
+        x=0.0,
+        y=0.0,
+        z=-1.7,
+        rotation_start_angle="-1 deg",
+        rotation_stop_angle="1 deg",
+    )
+
+    # TODO: Do we need to add the check whether the range of vertical angle limits is larger than the effective max scan angle in the Python code as well?
+    with pytest.raises(RuntimeError):
+        survey.run(format=OutputFormat.NPY)


### PR DESCRIPTION
Fix conditions for beam to return an echo to allow for non-symmetric vertical angle limits where max vertical angle is larger than effective max scan angle - add tests for this case

Background: Many TLS scanner (e.g. RIEGL) have a non-symmetric vertical field of view, such as -40° to +60°. With the previous criterion, the scan would have been cut off at +50°, because the maximum effective scan angle was specified as 50° (half angle). This PR fixes this and also adds a test that ensures this.