### PR TITLE
make WavefrontObjFileLoader handle mtl file names with spaces

### DIFF
--- a/src/assetloading/geometryfilter/WavefrontObjFileLoader.cpp
+++ b/src/assetloading/geometryfilter/WavefrontObjFileLoader.cpp
@@ -324,10 +324,9 @@ WavefrontObjFileLoader::loadObj(std::string const& pathString, bool const yIsUp)
             logging::WARN("Encountered 'mtllib' without a material filename.");
           } else {
             // Join all parts after "mtllib" to support filenames with spaces.
-            const std::string mtlFileName =
-              boost::algorithm::join(
-                std::vector<std::string>(lineParts.begin() + 1, lineParts.end()),
-                " ");
+            const std::string mtlFileName = boost::algorithm::join(
+              std::vector<std::string>(lineParts.begin() + 1, lineParts.end()),
+              " ");
 
             const fs::path matPath = filePath.parent_path() / mtlFileName;
             auto mats = MaterialsFileReader::loadMaterials(matPath.string());

--- a/src/assetloading/geometryfilter/WavefrontObjFileLoader.cpp
+++ b/src/assetloading/geometryfilter/WavefrontObjFileLoader.cpp
@@ -323,10 +323,13 @@ WavefrontObjFileLoader::loadObj(std::string const& pathString, bool const yIsUp)
           if (lineParts.size() < 2) {
             logging::WARN("Encountered 'mtllib' without a material filename.");
           } else {
-            // Join all parts after "mtllib" to support filenames with spaces.
-            const std::string mtlFileName = boost::algorithm::join(
-              std::vector<std::string>(lineParts.begin() + 1, lineParts.end()),
-              " ");
+            std::string mtlFileName;
+            for (std::size_t i = 1; i < lineParts.size(); ++i) {
+              if (i > 1) {
+                mtlFileName += ' ';
+              }
+              mtlFileName += lineParts[i];
+            }
 
             const fs::path matPath = filePath.parent_path() / mtlFileName;
             auto mats = MaterialsFileReader::loadMaterials(matPath.string());

--- a/src/assetloading/geometryfilter/WavefrontObjFileLoader.cpp
+++ b/src/assetloading/geometryfilter/WavefrontObjFileLoader.cpp
@@ -320,9 +320,19 @@ WavefrontObjFileLoader::loadObj(std::string const& pathString, bool const yIsUp)
 
         // Read materials
         else if (lineParts[0] == "mtllib") {
-          std::string s = filePath.parent_path().string() + "/" + lineParts[1];
-          auto mats = MaterialsFileReader::loadMaterials(s);
-          materials.insert(mats.begin(), mats.end());
+          if (lineParts.size() < 2) {
+            logging::WARN("Encountered 'mtllib' without a material filename.");
+          } else {
+            // Join all parts after "mtllib" to support filenames with spaces.
+            const std::string mtlFileName =
+              boost::algorithm::join(
+                std::vector<std::string>(lineParts.begin() + 1, lineParts.end()),
+                " ");
+
+            const fs::path matPath = filePath.parent_path() / mtlFileName;
+            auto mats = MaterialsFileReader::loadMaterials(matPath.string());
+            materials.insert(mats.begin(), mats.end());
+          }
         }
 
         // Read material specification (line should have two parts)

--- a/src/test/AssetLoadingTest.cpp
+++ b/src/test/AssetLoadingTest.cpp
@@ -1,5 +1,8 @@
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <filesystem>
+#include <fstream>
 #undef WARN
 #undef INFO
 #include "logging.hpp"
@@ -8,6 +11,7 @@ bool logging::LOGGING_SHOW_TRACE, logging::LOGGING_SHOW_DEBUG,
   logging::LOGGING_SHOW_INFO, logging::LOGGING_SHOW_TIME,
   logging::LOGGING_SHOW_WARN, logging::LOGGING_SHOW_ERR;
 
+#include <WavefrontObjFileLoader.h>
 #include <assetloading/XmlAssetsLoader.h>
 #include <assetloading/XmlSceneLoader.h>
 #include <assetloading/XmlSurveyLoader.h>
@@ -532,5 +536,72 @@ TEST_CASE("Asset Loading Tests")
     REQUIRE(std::fabs(mpdiff[0]) <= eps);
     REQUIRE(std::fabs(mpdiff[1]) <= eps);
     REQUIRE(std::fabs(mpdiff[2]) <= eps);
+  }
+
+  SECTION("Test reading material from a .mtl file with spaces in the filename")
+  {
+    namespace fs = std::filesystem;
+
+    const fs::path tempDir =
+      fs::temp_directory_path() / "helios_wavefront_obj_space_mtl_test";
+    fs::create_directories(tempDir);
+
+    const fs::path mtlPath = tempDir / "my material file.mtl";
+    const fs::path objPath = tempDir / "test_file.obj";
+    {
+      std::ofstream mtlOut(mtlPath);
+      REQUIRE(mtlOut.is_open());
+
+      mtlOut << "newmtl SpaceMat\n"
+                "Ka 0.10 0.20 0.30\n"
+                "Kd 0.40 0.50 0.60\n"
+                "Ks 0.70 0.80 0.90\n";
+    }
+
+    {
+      std::ofstream objOut(objPath);
+      REQUIRE(objOut.is_open());
+
+      objOut << "mtllib my material file.mtl\n"
+                "usemtl SpaceMat\n"
+                "v 0 0 0\n"
+                "v 1 0 0\n"
+                "v 0 1 0\n"
+                "f 1 2 3\n";
+    }
+    WavefrontObjFileLoader loader;
+    std::vector<std::string> assetsDir = { tempDir.string() };
+    loader.setAssetsDir(assetsDir);
+
+    std::map<std::string, ObjectT> params;
+    params["filepath"] = objPath.filename().string();
+    params["up"] = std::string("z");
+    params["recomputeVertexNormals"] = false;
+    loader.params = params;
+
+    ScenePart* scenePart = loader.run();
+    REQUIRE(scenePart != nullptr);
+    REQUIRE(scenePart->mPrimitives.size() == 1);
+
+    auto* tri = dynamic_cast<Triangle*>(scenePart->mPrimitives[0]);
+    REQUIRE(tri != nullptr);
+    REQUIRE(tri->material != nullptr);
+    REQUIRE(tri->material->matFilePath == mtlPath.string());
+    REQUIRE(tri->material->name == "SpaceMat");
+    const float eps = 1e-5f;
+
+    REQUIRE(tri->material->ka[0] == Catch::Approx(0.10f).margin(eps));
+    REQUIRE(tri->material->ka[1] == Catch::Approx(0.20f).margin(eps));
+    REQUIRE(tri->material->ka[2] == Catch::Approx(0.30f).margin(eps));
+
+    REQUIRE(tri->material->kd[0] == Catch::Approx(0.40f).margin(eps));
+    REQUIRE(tri->material->kd[1] == Catch::Approx(0.50f).margin(eps));
+    REQUIRE(tri->material->kd[2] == Catch::Approx(0.60f).margin(eps));
+
+    REQUIRE(tri->material->ks[0] == Catch::Approx(0.70f).margin(eps));
+    REQUIRE(tri->material->ks[1] == Catch::Approx(0.80f).margin(eps));
+    REQUIRE(tri->material->ks[2] == Catch::Approx(0.90f).margin(eps));
+
+    fs::remove_all(tempDir);
   }
 }


### PR DESCRIPTION
I noticed a special case when trying to read OBJ files and their MTL files. If the MTL file contains spaces (which can often happen with automatic exports from Blender), the previous logic in WavefrontObjFileLoader.cpp would read only the part until the first space as file name, and then throw a RuntimeError because that path is not found. This PR should fix it and make reading MTL files more robust.

NOTE: This fix could also go in `main` in parallel.