### PR TITLE
Normalize scanner setting fallbacks

### DIFF
--- a/pytests/test_pyhelios.py
+++ b/pytests/test_pyhelios.py
@@ -354,8 +354,8 @@ def test_programmatic_new_leg_inherits_scanner_defaults(output_dir, tmp_path):
     assert leg.getScannerSettings().active is True
 
 
-def test_unsupported_pulse_frequency_is_overwritten_in_survey(test_sim, tmp_path):
-    """Unsupported survey pulse frequencies should fall back to the scanner definition."""
+def test_missing_pulse_frequency_uses_scanner_defaults_in_survey(test_sim, tmp_path):
+    """Missing survey pulse frequencies should inherit the scanner definition."""
     survey_path = tmp_path / "livox_unsupported_pulse_freq.xml"
     survey_path.write_text(
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -363,7 +363,7 @@ def test_unsupported_pulse_frequency_is_overwritten_in_survey(test_sim, tmp_path
     <survey name="test_scan" scene="data/scenes/toyblocks/toyblocks_scene.xml#toyblocks_scene" platform="data/platforms.xml#tripod" scanner="data/scanners_tls.xml#livox_mid-70">
         <leg>
             <platformSettings x="0.0" y="0.0" z="0.0" />
-            <scannerSettings active="true" pulseFreq_hz="300000" trajectoryTimeInterval_s="0.01" />
+            <scannerSettings active="true" trajectoryTimeInterval_s="0.01" />
         </leg>
     </survey>
 </document>

--- a/pytests/test_pyhelios.py
+++ b/pytests/test_pyhelios.py
@@ -324,6 +324,57 @@ def test_create_survey(output_dir):
     )
 
 
+def test_programmatic_new_leg_inherits_scanner_defaults(output_dir, tmp_path):
+    """Programmatically created legs should inherit scanner defaults."""
+    survey_path = tmp_path / "livox_programmatic_leg.xml"
+    survey_path.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<document>
+    <survey name="test_scan" scene="data/scenes/toyblocks/toyblocks_scene.xml#toyblocks_scene" platform="data/platforms.xml#tripod" scanner="data/scanners_tls.xml#livox_mid-70">
+    </survey>
+</document>
+""",
+        encoding="utf-8",
+    )
+
+    sim_builder = pyhelios.SimulationBuilder(str(survey_path), "assets/", str(output_dir))
+    sim_builder.setFinalOutput(False)
+    sim_builder.setLasOutput(False)
+    sim_builder.setZipOutput(False)
+    sim_builder.setRebuildScene(True)
+    sim_builder.setNumThreads(1)
+    sim_builder.setKDTJobs(1)
+
+    sim_build = sim_builder.build()
+    leg = sim_build.sim.newLeg(0)
+
+    assert leg.getScannerSettings().pulseFreq == 100_000
+    assert leg.getScannerSettings().active is True
+
+
+def test_unsupported_pulse_frequency_is_overwritten_in_survey(test_sim, tmp_path):
+    """Unsupported survey pulse frequencies should fall back to the scanner definition."""
+    survey_path = tmp_path / "livox_unsupported_pulse_freq.xml"
+    survey_path.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<document>
+    <survey name="test_scan" scene="data/scenes/toyblocks/toyblocks_scene.xml#toyblocks_scene" platform="data/platforms.xml#tripod" scanner="data/scanners_tls.xml#livox_mid-70">
+        <leg>
+            <platformSettings x="0.0" y="0.0" z="0.0" />
+            <scannerSettings active="true" pulseFreq_hz="300000" trajectoryTimeInterval_s="0.01" />
+        </leg>
+    </survey>
+</document>
+""",
+        encoding="utf-8",
+    )
+
+    sim = test_sim(survey_path, las_output=False, zip_output=False)
+    leg = sim.sim.getLeg(0)
+
+    assert leg.getScannerSettings().pulseFreq == 100_000
+
+
 def test_material(test_sim):
     """Test accessing material properties of a primitive in a scene"""
     sim = test_sim(Path("data") / "surveys" / "toyblocks" / "als_toyblocks.xml")

--- a/pytests/test_pyhelios.py
+++ b/pytests/test_pyhelios.py
@@ -337,7 +337,9 @@ def test_programmatic_new_leg_inherits_scanner_defaults(output_dir, tmp_path):
         encoding="utf-8",
     )
 
-    sim_builder = pyhelios.SimulationBuilder(str(survey_path), "assets/", str(output_dir))
+    sim_builder = pyhelios.SimulationBuilder(
+        str(survey_path), "assets/", str(output_dir)
+    )
     sim_builder.setFinalOutput(False)
     sim_builder.setLasOutput(False)
     sim_builder.setZipOutput(False)

--- a/src/assetloading/XmlSurveyLoader.cpp
+++ b/src/assetloading/XmlSurveyLoader.cpp
@@ -13,11 +13,44 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 
+#include <algorithm>
 #include <chrono>
 #include <memory>
 #include <unordered_set>
 
 namespace fs = boost::filesystem;
+
+namespace {
+void
+normalizeUnsupportedPulseFrequency(std::shared_ptr<Scanner> const& scanner,
+                                   std::shared_ptr<ScannerSettings> const& settings,
+                                   int const legSerialId)
+{
+  if (scanner == nullptr || settings == nullptr) {
+    return;
+  }
+
+  std::list<int> const& supportedPulseFreqs = scanner->getSupportedPulseFreqs_Hz();
+  if (supportedPulseFreqs.empty()) {
+    return;
+  }
+
+  if (std::find(supportedPulseFreqs.begin(),
+                supportedPulseFreqs.end(),
+                settings->pulseFreq_Hz) != supportedPulseFreqs.end()) {
+    return;
+  }
+
+  int const fallbackPulseFreq_Hz = supportedPulseFreqs.front();
+  std::stringstream ss;
+  ss << "Scanner settings of leg " << legSerialId
+     << " requested unsupported pulse frequency " << settings->pulseFreq_Hz
+     << " Hz. Using " << fallbackPulseFreq_Hz
+     << " Hz from the scanner definition instead.";
+  logging::INFO(ss.str());
+  settings->pulseFreq_Hz = fallbackPulseFreq_Hz;
+}
+}
 
 std::shared_ptr<Survey>
 XmlSurveyLoader::load(bool legNoiseDisabled, bool rebuildScene)
@@ -577,6 +610,10 @@ XmlSurveyLoader::integrateSurveyAndLegs(std::shared_ptr<Survey> survey)
 {
   // Obtain legs
   std::vector<std::shared_ptr<Leg>>& legs = survey->legs;
+  for (std::shared_ptr<Leg> const& leg : legs) {
+    normalizeUnsupportedPulseFrequency(
+      survey->scanner, leg->mScannerSettings, leg->getSerialId());
+  }
 
   // Handle scanAngleMax/scanAngleEffectiveMax != 1
   std::shared_ptr<PolygonMirrorBeamDeflector> pmbd =

--- a/src/assetloading/XmlSurveyLoader.cpp
+++ b/src/assetloading/XmlSurveyLoader.cpp
@@ -13,46 +13,11 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 
-#include <algorithm>
 #include <chrono>
 #include <memory>
 #include <unordered_set>
 
 namespace fs = boost::filesystem;
-
-namespace {
-void
-normalizeUnsupportedPulseFrequency(
-  std::shared_ptr<Scanner> const& scanner,
-  std::shared_ptr<ScannerSettings> const& settings,
-  int const legSerialId)
-{
-  if (scanner == nullptr || settings == nullptr) {
-    return;
-  }
-
-  std::list<int> const& supportedPulseFreqs =
-    scanner->getSupportedPulseFreqs_Hz();
-  if (supportedPulseFreqs.empty()) {
-    return;
-  }
-
-  if (std::find(supportedPulseFreqs.begin(),
-                supportedPulseFreqs.end(),
-                settings->pulseFreq_Hz) != supportedPulseFreqs.end()) {
-    return;
-  }
-
-  int const fallbackPulseFreq_Hz = supportedPulseFreqs.front();
-  std::stringstream ss;
-  ss << "Scanner settings of leg " << legSerialId
-     << " requested unsupported pulse frequency " << settings->pulseFreq_Hz
-     << " Hz. Using " << fallbackPulseFreq_Hz
-     << " Hz from the scanner definition instead.";
-  logging::INFO(ss.str());
-  settings->pulseFreq_Hz = fallbackPulseFreq_Hz;
-}
-}
 
 std::shared_ptr<Survey>
 XmlSurveyLoader::load(bool legNoiseDisabled, bool rebuildScene)
@@ -612,11 +577,6 @@ XmlSurveyLoader::integrateSurveyAndLegs(std::shared_ptr<Survey> survey)
 {
   // Obtain legs
   std::vector<std::shared_ptr<Leg>>& legs = survey->legs;
-  for (std::shared_ptr<Leg> const& leg : legs) {
-    normalizeUnsupportedPulseFrequency(
-      survey->scanner, leg->mScannerSettings, leg->getSerialId());
-  }
-
   // Handle scanAngleMax/scanAngleEffectiveMax != 1
   std::shared_ptr<PolygonMirrorBeamDeflector> pmbd =
     std::dynamic_pointer_cast<PolygonMirrorBeamDeflector>(

--- a/src/assetloading/XmlSurveyLoader.cpp
+++ b/src/assetloading/XmlSurveyLoader.cpp
@@ -22,15 +22,17 @@ namespace fs = boost::filesystem;
 
 namespace {
 void
-normalizeUnsupportedPulseFrequency(std::shared_ptr<Scanner> const& scanner,
-                                   std::shared_ptr<ScannerSettings> const& settings,
-                                   int const legSerialId)
+normalizeUnsupportedPulseFrequency(
+  std::shared_ptr<Scanner> const& scanner,
+  std::shared_ptr<ScannerSettings> const& settings,
+  int const legSerialId)
 {
   if (scanner == nullptr || settings == nullptr) {
     return;
   }
 
-  std::list<int> const& supportedPulseFreqs = scanner->getSupportedPulseFreqs_Hz();
+  std::list<int> const& supportedPulseFreqs =
+    scanner->getSupportedPulseFreqs_Hz();
   if (supportedPulseFreqs.empty()) {
     return;
   }

--- a/src/pybinds/PyHeliosSimulation.cpp
+++ b/src/pybinds/PyHeliosSimulation.cpp
@@ -112,8 +112,18 @@ PyHeliosSimulation::newLeg(int index)
   if (index < 0 || index > n)
     index = n;
   std::shared_ptr<Leg> leg = std::make_shared<Leg>();
-  leg->mScannerSettings = std::make_shared<ScannerSettings>();
-  leg->mPlatformSettings = std::make_shared<PlatformSettings>();
+  if (survey != nullptr && survey->scanner != nullptr) {
+    leg->mScannerSettings = survey->scanner->retrieveCurrentSettings();
+    if (survey->scanner->platform != nullptr) {
+      leg->mPlatformSettings = survey->scanner->platform->retrieveCurrentSettings();
+    }
+  }
+  if (leg->mScannerSettings == nullptr) {
+    leg->mScannerSettings = std::make_shared<ScannerSettings>();
+  }
+  if (leg->mPlatformSettings == nullptr) {
+    leg->mPlatformSettings = std::make_shared<PlatformSettings>();
+  }
   survey->addLeg(index, leg);
   return *leg;
 }

--- a/src/pybinds/PyHeliosSimulation.cpp
+++ b/src/pybinds/PyHeliosSimulation.cpp
@@ -115,7 +115,8 @@ PyHeliosSimulation::newLeg(int index)
   if (survey != nullptr && survey->scanner != nullptr) {
     leg->mScannerSettings = survey->scanner->retrieveCurrentSettings();
     if (survey->scanner->platform != nullptr) {
-      leg->mPlatformSettings = survey->scanner->platform->retrieveCurrentSettings();
+      leg->mPlatformSettings =
+        survey->scanner->platform->retrieveCurrentSettings();
     }
   }
   if (leg->mScannerSettings == nullptr) {

--- a/src/pybinds/PyHeliosSimulation.cpp
+++ b/src/pybinds/PyHeliosSimulation.cpp
@@ -112,18 +112,10 @@ PyHeliosSimulation::newLeg(int index)
   if (index < 0 || index > n)
     index = n;
   std::shared_ptr<Leg> leg = std::make_shared<Leg>();
+  leg->mScannerSettings = std::make_shared<ScannerSettings>();
+  leg->mPlatformSettings = std::make_shared<PlatformSettings>();
   if (survey != nullptr && survey->scanner != nullptr) {
-    leg->mScannerSettings = survey->scanner->retrieveCurrentSettings();
-    if (survey->scanner->platform != nullptr) {
-      leg->mPlatformSettings =
-        survey->scanner->platform->retrieveCurrentSettings();
-    }
-  }
-  if (leg->mScannerSettings == nullptr) {
-    leg->mScannerSettings = std::make_shared<ScannerSettings>();
-  }
-  if (leg->mPlatformSettings == nullptr) {
-    leg->mPlatformSettings = std::make_shared<PlatformSettings>();
+    leg->mScannerSettings->pulseFreq_Hz = survey->scanner->getPulseFreq_Hz();
   }
   survey->addLeg(index, leg);
   return *leg;

--- a/src/scanner/Scanner.cpp
+++ b/src/scanner/Scanner.cpp
@@ -261,8 +261,8 @@ Scanner::setPulseFreq_Hz(int pulseFreq_Hz)
       int const fallbackPulseFreq_Hz = supportedPulseFreqs.front();
       std::stringstream ws;
       ws << "WARNING: Specified pulse frequency " << pulseFreq_Hz
-         << " is not supported by this device. Using "
-         << fallbackPulseFreq_Hz << " Hz from the scanner definition instead.";
+         << " is not supported by this device. Using " << fallbackPulseFreq_Hz
+         << " Hz from the scanner definition instead.";
       logging::WARN(ws.str());
       pulseFreq_Hz = fallbackPulseFreq_Hz;
     } else {

--- a/src/scanner/Scanner.cpp
+++ b/src/scanner/Scanner.cpp
@@ -253,23 +253,11 @@ Scanner::setPulseFreq_Hz(int pulseFreq_Hz)
   }
 
   // Check if requested pulse freq is supported by device:
-  std::list<int> const& supportedPulseFreqs = getSupportedPulseFreqs_Hz();
-  if (std::find(supportedPulseFreqs.begin(),
-                supportedPulseFreqs.end(),
-                pulseFreq_Hz) == supportedPulseFreqs.end()) {
-    if (!supportedPulseFreqs.empty()) {
-      int const fallbackPulseFreq_Hz = supportedPulseFreqs.front();
-      std::stringstream ws;
-      ws << "WARNING: Specified pulse frequency " << pulseFreq_Hz
-         << " is not supported by this device. Using " << fallbackPulseFreq_Hz
-         << " Hz from the scanner definition instead.";
-      logging::WARN(ws.str());
-      pulseFreq_Hz = fallbackPulseFreq_Hz;
-    } else {
-      logging::WARN("WARNING: Specified pulse frequency is not supported "
-                    "by this device and no supported fallback was declared. "
-                    "We'll set it nevertheless.\n");
-    }
+  if (std::find(getSupportedPulseFreqs_Hz().begin(),
+                getSupportedPulseFreqs_Hz().end(),
+                pulseFreq_Hz) == getSupportedPulseFreqs_Hz().end()) {
+    logging::WARN("WARNING: Specified pulse frequency is not supported "
+                  "by this device. We'll set it nevertheless.\n");
   }
 
   // Set new pulse frequency:

--- a/src/scanner/Scanner.cpp
+++ b/src/scanner/Scanner.cpp
@@ -253,11 +253,23 @@ Scanner::setPulseFreq_Hz(int pulseFreq_Hz)
   }
 
   // Check if requested pulse freq is supported by device:
-  if (std::find(getSupportedPulseFreqs_Hz().begin(),
-                getSupportedPulseFreqs_Hz().end(),
-                pulseFreq_Hz) == getSupportedPulseFreqs_Hz().end()) {
-    logging::WARN("WARNING: Specified pulse frequency is not supported "
-                  "by this device. We'll set it nevertheless.\n");
+  std::list<int> const& supportedPulseFreqs = getSupportedPulseFreqs_Hz();
+  if (std::find(supportedPulseFreqs.begin(),
+                supportedPulseFreqs.end(),
+                pulseFreq_Hz) == supportedPulseFreqs.end()) {
+    if (!supportedPulseFreqs.empty()) {
+      int const fallbackPulseFreq_Hz = supportedPulseFreqs.front();
+      std::stringstream ws;
+      ws << "WARNING: Specified pulse frequency " << pulseFreq_Hz
+         << " is not supported by this device. Using "
+         << fallbackPulseFreq_Hz << " Hz from the scanner definition instead.";
+      logging::WARN(ws.str());
+      pulseFreq_Hz = fallbackPulseFreq_Hz;
+    } else {
+      logging::WARN("WARNING: Specified pulse frequency is not supported "
+                    "by this device and no supported fallback was declared. "
+                    "We'll set it nevertheless.\n");
+    }
   }
 
   // Set new pulse frequency:


### PR DESCRIPTION
## Summary
- keep explicitly configured unsupported pulse frequencies unchanged while still inheriting scanner defaults for missing survey pulse frequencies
- initialize programmatically created legs with the current scanner pulse frequency instead of an empty pulse-frequency setting
- add regression tests for the Livox missing-pulse-frequency survey case and `newLeg()` defaults

Closes #823.
