### PR TITLE
Support per-leg scanner mount overrides

### DIFF
--- a/data/test/tls_leg_scanner_mount.xml
+++ b/data/test/tls_leg_scanner_mount.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document>
+    <platformSettings id="tilted_mount">
+        <scannerMount x="0.0" y="0.0" z="1.8">
+            <rot axis="z" angle_deg="45"/>
+        </scannerMount>
+    </platformSettings>
+    <survey name="tls_leg_scanner_mount"
+            scene="data/scenes/demo/box_scene.xml#box_scene"
+            platform="data/platforms.xml#tripod"
+            scanner="data/scanners_tls.xml#livox_mid-70">
+        <leg maxDuration_s="0.1">
+            <platformSettings x="0.0" y="0.0" z="0.0" template="tilted_mount"/>
+            <scannerSettings active="true"
+                             pulseFreq_hz="100000"
+                             trajectoryTimeInterval_s="0.01"/>
+        </leg>
+        <leg maxDuration_s="0.1">
+            <platformSettings x="0.0" y="0.0" z="0.0">
+                <scannerMount x="0.25" y="0.0" z="2.0">
+                    <rot axis="x" angle_deg="20"/>
+                </scannerMount>
+            </platformSettings>
+            <scannerSettings active="true"
+                             pulseFreq_hz="100000"
+                             trajectoryTimeInterval_s="0.01"/>
+        </leg>
+        <leg maxDuration_s="0.1">
+            <platformSettings x="0.0" y="0.0" z="0.0"/>
+            <scannerSettings active="true"
+                             pulseFreq_hz="100000"
+                             trajectoryTimeInterval_s="0.01"/>
+        </leg>
+    </survey>
+</document>

--- a/pytests/test_pyhelios.py
+++ b/pytests/test_pyhelios.py
@@ -224,6 +224,74 @@ def test_templates(test_sim):
     assert ps_templ.movePerSec == 30
 
 
+def test_leg_platform_settings_can_override_scanner_mount(test_sim):
+    """Test per-leg scannerMount overrides through platformSettings."""
+    sim = test_sim(
+        Path("data") / "test" / "tls_leg_scanner_mount.xml",
+        las_output=False,
+        zip_output=False,
+    )
+
+    templated_ps = sim.sim.getLeg(0).getPlatformSettings()
+    templated_mount_pos = templated_ps.getRelativeMountPosition()
+    templated_mount_att = templated_ps.getRelativeMountAttitude()
+    templated_axis = templated_mount_att.getAxis()
+
+    assert templated_mount_pos.x == pytest.approx(0.0)
+    assert templated_mount_pos.y == pytest.approx(0.0)
+    assert templated_mount_pos.z == pytest.approx(1.8)
+    assert abs(templated_axis.x) == pytest.approx(0.0)
+    assert abs(templated_axis.y) == pytest.approx(0.0)
+    assert abs(templated_axis.z) == pytest.approx(1.0)
+    assert templated_mount_att.getAngle() == pytest.approx(np.deg2rad(45.0))
+
+    inline_ps = sim.sim.getLeg(1).getPlatformSettings()
+    inline_mount_pos = inline_ps.getRelativeMountPosition()
+    inline_mount_att = inline_ps.getRelativeMountAttitude()
+    inline_axis = inline_mount_att.getAxis()
+
+    assert inline_mount_pos.x == pytest.approx(0.25)
+    assert inline_mount_pos.y == pytest.approx(0.0)
+    assert inline_mount_pos.z == pytest.approx(2.0)
+    assert abs(inline_axis.x) == pytest.approx(1.0)
+    assert abs(inline_axis.y) == pytest.approx(0.0)
+    assert abs(inline_axis.z) == pytest.approx(0.0)
+    assert inline_mount_att.getAngle() == pytest.approx(np.deg2rad(20.0))
+
+    default_ps = sim.sim.getLeg(2).getPlatformSettings()
+    default_mount_pos = default_ps.getRelativeMountPosition()
+    default_mount_att = default_ps.getRelativeMountAttitude()
+
+    assert default_mount_pos.x == pytest.approx(0.0)
+    assert default_mount_pos.y == pytest.approx(0.0)
+    assert default_mount_pos.z == pytest.approx(1.5)
+    assert default_mount_att.getAngle() == pytest.approx(0.0)
+
+
+def test_new_leg_uses_current_platform_mount_defaults(test_sim):
+    """Test new legs inherit the current platform mount as their base settings."""
+    sim = test_sim(
+        Path("data") / "test" / "tls_leg_scanner_mount.xml",
+        las_output=False,
+        zip_output=False,
+    )
+    platform = sim.sim.getPlatform()
+    base_mount_pos = platform.getRelativePosition()
+    base_mount_att = platform.getRelativeAttitude()
+
+    leg = sim.sim.newLeg(sim.sim.getNumLegs())
+    leg_mount_pos = leg.getPlatformSettings().getRelativeMountPosition()
+    leg_mount_att = leg.getPlatformSettings().getRelativeMountAttitude()
+
+    assert leg_mount_pos.x == pytest.approx(base_mount_pos.x)
+    assert leg_mount_pos.y == pytest.approx(base_mount_pos.y)
+    assert leg_mount_pos.z == pytest.approx(base_mount_pos.z)
+    assert leg_mount_att.q0 == pytest.approx(base_mount_att.q0)
+    assert leg_mount_att.q1 == pytest.approx(base_mount_att.q1)
+    assert leg_mount_att.q2 == pytest.approx(base_mount_att.q2)
+    assert leg_mount_att.q3 == pytest.approx(base_mount_att.q3)
+
+
 def test_survey_characteristics(test_sim):
     """Test accessing survey characteristics (name, length)"""
     path_to_survey = Path("data") / "surveys" / "toyblocks" / "als_toyblocks.xml"

--- a/python/pyhelios/util/xsd/survey.xsd
+++ b/python/pyhelios/util/xsd/survey.xsd
@@ -61,21 +61,39 @@
                             </xs:element>
                 <xs:element ref="scannerSettings" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="platformSettings" minOccurs="0" maxOccurs="unbounded">
-                    <xs:complexType>
-                        <xs:simpleContent>
-                            <xs:extension base="xs:string">
-                                <xs:attribute type="xs:string" name="id" use="required"/>
-                                <xs:attribute type="xs:float" name="x" use="optional"/>
-                                <xs:attribute type="xs:float" name="y" use="optional"/>
-                                <xs:attribute type="xs:float" name="z" use="optional"/>
-                                <xs:attribute type="xs:float" name="movePerSec_m" use="optional"/>
-                                <xs:attribute type="xs:boolean" name="onGround" use="optional"/>
-                                <xs:attribute type="xs:boolean" name="stopAndTurn" use="optional"/>
-                                <xs:attribute type="xs:boolean" name="smoothTurn" use="optional"/>
-                                <xs:attribute type="xs:boolean" name="slowdownEnabled" use="optional"/>
-                                <xs:attribute type="xs:float" name="yawAtDeparture_deg" use="optional"/>
-                            </xs:extension>
-                        </xs:simpleContent>
+                    <xs:complexType mixed="true">
+                        <xs:sequence>
+                            <xs:element name="scannerMount" maxOccurs="1" minOccurs="0">
+                                <xs:complexType mixed="true">
+                                    <xs:sequence>
+                                        <xs:element name="rot" maxOccurs="unbounded" minOccurs="0">
+                                            <xs:complexType>
+                                                <xs:simpleContent>
+                                                    <xs:extension base="xs:string">
+                                                        <xs:attribute type="axisType" name="axis" use="optional"/>
+                                                        <xs:attribute type="xs:float" name="angle_deg" use="optional"/>
+                                                    </xs:extension>
+                                                </xs:simpleContent>
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                    <xs:attribute type="xs:float" name="x" use="optional"/>
+                                    <xs:attribute type="xs:float" name="y" use="optional"/>
+                                    <xs:attribute type="xs:float" name="z" use="optional"/>
+                                    <xs:attribute type="rotType" name="rotations" use="optional"/>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute type="xs:string" name="id" use="required"/>
+                        <xs:attribute type="xs:float" name="x" use="optional"/>
+                        <xs:attribute type="xs:float" name="y" use="optional"/>
+                        <xs:attribute type="xs:float" name="z" use="optional"/>
+                        <xs:attribute type="xs:float" name="movePerSec_m" use="optional"/>
+                        <xs:attribute type="xs:boolean" name="onGround" use="optional"/>
+                        <xs:attribute type="xs:boolean" name="stopAndTurn" use="optional"/>
+                        <xs:attribute type="xs:boolean" name="smoothTurn" use="optional"/>
+                        <xs:attribute type="xs:boolean" name="slowdownEnabled" use="optional"/>
+                        <xs:attribute type="xs:float" name="yawAtDeparture_deg" use="optional"/>
                     </xs:complexType>
                 </xs:element>
                 <xs:element name="survey" minOccurs="1" maxOccurs="1">
@@ -128,36 +146,54 @@
                                 <xs:complexType>
                                     <xs:sequence>
                                         <xs:element name="platformSettings">
-                                            <xs:complexType>
-                                                <xs:simpleContent>
-                                                    <xs:extension base="xs:string">
-                                                        <xs:attribute type="xs:string" name="template" use="optional"/>
-                                                        <xs:attribute type="xs:float" name="x" use="optional"/>
-                                                        <xs:attribute type="xs:float" name="y" use="optional"/>
-                                                        <xs:attribute type="xs:float" name="z" use="optional"/>
-                                                        <xs:attribute type="xs:float" name="movePerSec_m" use="optional"/>
-                                                        <xs:attribute type="xs:boolean" name="onGround" use="optional"/>
-                                                        <xs:attribute type="xs:boolean" name="stopAndTurn" use="optional"/>
-                                                        <xs:attribute type="xs:boolean" name="smoothTurn" use="optional"/>
-                                                        <xs:attribute type="xs:boolean" name="slowdownEnabled" use="optional"/>
-                                                        <xs:attribute type="xs:float" name="yawAtDeparture_deg" use="optional"/>
-                                                        <xs:attribute type="xs:string" name="trajectory" use="optional"/>
-                                                        <xs:attribute type="xs:string" name="trajectory_separator" use="optional"/>
-                                                        <xs:attribute type="xs:int" name="xIndex" use="optional"/>
-                                                        <xs:attribute type="xs:int" name="yIndex" use="optional"/>
-                                                        <xs:attribute type="xs:int" name="zIndex" use="optional"/>
-                                                        <xs:attribute type="xs:int" name="tIndex" use="optional"/>
-                                                        <xs:attribute type="xs:int" name="rollIndex" use="optional"/>
-                                                        <xs:attribute type="xs:int" name="pitchIndex" use="optional"/>
-                                                        <xs:attribute type="xs:int" name="yawIndex" use="optional"/>
-                                                        <xs:attribute type="xs:float" name="tStart" use="optional"/>
-                                                        <xs:attribute type="xs:float" name="tEnd" use="optional"/>
-                                                        <xs:attribute type="xs:float" name="slopeFilterThreshold" use="optional"/>
-                                                        <xs:attribute type="xs:boolean" name="syncGPSTime" use="optional"/>
-                                                        <xs:attribute type="xs:boolean" name="teleportToStart" use="optional"/>
-                                                        <xs:attribute type="xs:boolean" name="toRadians" use="optional"/>
-                                                    </xs:extension>
-                                                </xs:simpleContent>
+                                            <xs:complexType mixed="true">
+                                                <xs:sequence>
+                                                    <xs:element name="scannerMount" maxOccurs="1" minOccurs="0">
+                                                        <xs:complexType mixed="true">
+                                                            <xs:sequence>
+                                                                <xs:element name="rot" maxOccurs="unbounded" minOccurs="0">
+                                                                    <xs:complexType>
+                                                                        <xs:simpleContent>
+                                                                            <xs:extension base="xs:string">
+                                                                                <xs:attribute type="axisType" name="axis" use="optional"/>
+                                                                                <xs:attribute type="xs:float" name="angle_deg" use="optional"/>
+                                                                            </xs:extension>
+                                                                        </xs:simpleContent>
+                                                                    </xs:complexType>
+                                                                </xs:element>
+                                                            </xs:sequence>
+                                                            <xs:attribute type="xs:float" name="x" use="optional"/>
+                                                            <xs:attribute type="xs:float" name="y" use="optional"/>
+                                                            <xs:attribute type="xs:float" name="z" use="optional"/>
+                                                            <xs:attribute type="rotType" name="rotations" use="optional"/>
+                                                        </xs:complexType>
+                                                    </xs:element>
+                                                </xs:sequence>
+                                                <xs:attribute type="xs:string" name="template" use="optional"/>
+                                                <xs:attribute type="xs:float" name="x" use="optional"/>
+                                                <xs:attribute type="xs:float" name="y" use="optional"/>
+                                                <xs:attribute type="xs:float" name="z" use="optional"/>
+                                                <xs:attribute type="xs:float" name="movePerSec_m" use="optional"/>
+                                                <xs:attribute type="xs:boolean" name="onGround" use="optional"/>
+                                                <xs:attribute type="xs:boolean" name="stopAndTurn" use="optional"/>
+                                                <xs:attribute type="xs:boolean" name="smoothTurn" use="optional"/>
+                                                <xs:attribute type="xs:boolean" name="slowdownEnabled" use="optional"/>
+                                                <xs:attribute type="xs:float" name="yawAtDeparture_deg" use="optional"/>
+                                                <xs:attribute type="xs:string" name="trajectory" use="optional"/>
+                                                <xs:attribute type="xs:string" name="trajectory_separator" use="optional"/>
+                                                <xs:attribute type="xs:int" name="xIndex" use="optional"/>
+                                                <xs:attribute type="xs:int" name="yIndex" use="optional"/>
+                                                <xs:attribute type="xs:int" name="zIndex" use="optional"/>
+                                                <xs:attribute type="xs:int" name="tIndex" use="optional"/>
+                                                <xs:attribute type="xs:int" name="rollIndex" use="optional"/>
+                                                <xs:attribute type="xs:int" name="pitchIndex" use="optional"/>
+                                                <xs:attribute type="xs:int" name="yawIndex" use="optional"/>
+                                                <xs:attribute type="xs:float" name="tStart" use="optional"/>
+                                                <xs:attribute type="xs:float" name="tEnd" use="optional"/>
+                                                <xs:attribute type="xs:float" name="slopeFilterThreshold" use="optional"/>
+                                                <xs:attribute type="xs:boolean" name="syncGPSTime" use="optional"/>
+                                                <xs:attribute type="xs:boolean" name="teleportToStart" use="optional"/>
+                                                <xs:attribute type="xs:boolean" name="toRadians" use="optional"/>
                                             </xs:complexType>
                                         </xs:element>
                                         <xs:element name="scannerSettings">

--- a/src/assetloading/XmlAssetsLoader.cpp
+++ b/src/assetloading/XmlAssetsLoader.cpp
@@ -315,7 +315,8 @@ XmlAssetsLoader::createPlatformSettingsFromXml(
     node, "y", template1->y, defaultPlatformSettingsMsg);
   settings->z = XmlUtils::getAttributeCast<double>(
     node, "z", template1->z, defaultPlatformSettingsMsg);
-  tinyxml2::XMLElement* scannerMountNode = node->FirstChildElement("scannerMount");
+  tinyxml2::XMLElement* scannerMountNode =
+    node->FirstChildElement("scannerMount");
   if (scannerMountNode != nullptr) {
     settings->relativeMountPosition =
       XmlUtils::createVec3dFromXml(scannerMountNode, "");

--- a/src/assetloading/XmlAssetsLoader.cpp
+++ b/src/assetloading/XmlAssetsLoader.cpp
@@ -315,6 +315,16 @@ XmlAssetsLoader::createPlatformSettingsFromXml(
     node, "y", template1->y, defaultPlatformSettingsMsg);
   settings->z = XmlUtils::getAttributeCast<double>(
     node, "z", template1->z, defaultPlatformSettingsMsg);
+  tinyxml2::XMLElement* scannerMountNode = node->FirstChildElement("scannerMount");
+  if (scannerMountNode != nullptr) {
+    settings->relativeMountPosition =
+      XmlUtils::createVec3dFromXml(scannerMountNode, "");
+    settings->relativeMountAttitude =
+      XmlUtils::createRotationFromXml(scannerMountNode);
+  } else {
+    settings->relativeMountPosition = template1->relativeMountPosition;
+    settings->relativeMountAttitude = template1->relativeMountAttitude;
+  }
 
   // Read if platform should be put on ground, ignoring z coordinate:
   settings->onGround = XmlUtils::getAttributeCast<bool>(
@@ -1728,6 +1738,13 @@ XmlAssetsLoader::trackNonDefaultPlatformSettings(
   std::string const defaultTemplateId,
   std::unordered_set<std::string>& fields)
 {
+  auto sameVec3 = [](glm::dvec3 const& a, glm::dvec3 const& b) -> bool {
+    return a.x == b.x && a.y == b.y && a.z == b.z;
+  };
+  auto sameRotation = [](Rotation const& a, Rotation const& b) -> bool {
+    return a.getQ0() == b.getQ0() && a.getQ1() == b.getQ1() &&
+           a.getQ2() == b.getQ2() && a.getQ3() == b.getQ3();
+  };
   if (ref->id != defaultTemplateId)
     fields.insert("baseTemplate");
   if (base->x != ref->x)
@@ -1740,6 +1757,10 @@ XmlAssetsLoader::trackNonDefaultPlatformSettings(
     fields.insert("yawAtDepartureSpecified");
   if (base->yawAtDeparture != ref->yawAtDeparture)
     fields.insert("yawAtDeparture");
+  if (!sameVec3(base->relativeMountPosition, ref->relativeMountPosition))
+    fields.insert("relativeMountPosition");
+  if (!sameRotation(base->relativeMountAttitude, ref->relativeMountAttitude))
+    fields.insert("relativeMountAttitude");
   if (base->onGround != ref->onGround)
     fields.insert("onGround");
   if (base->stopAndTurn != ref->stopAndTurn)

--- a/src/assetloading/XmlSurveyLoader.cpp
+++ b/src/assetloading/XmlSurveyLoader.cpp
@@ -404,7 +404,8 @@ XmlSurveyLoader::loadLegs(tinyxml2::XMLElement* legNodes,
           platformSettings->yawAtDepartureSpecified) {
         effectivePlatformFields.insert("yawAtDepartureSpecified");
       }
-      if (rawPlatformSettings->yawAtDeparture != platformSettings->yawAtDeparture)
+      if (rawPlatformSettings->yawAtDeparture !=
+          platformSettings->yawAtDeparture)
         effectivePlatformFields.insert("yawAtDeparture");
       if (!sameVec3(rawPlatformSettings->relativeMountPosition,
                     platformSettings->relativeMountPosition)) {
@@ -428,14 +429,14 @@ XmlSurveyLoader::loadLegs(tinyxml2::XMLElement* legNodes,
         effectivePlatformFields.insert("movePerSec_m");
     }
     effectivePlatformFields.erase("baseTemplate");
-    leg->mPlatformSettings =
-      platformSettings->cherryPick(rawPlatformSettings, effectivePlatformFields);
+    leg->mPlatformSettings = platformSettings->cherryPick(
+      rawPlatformSettings, effectivePlatformFields);
     if (hasCustomPlatformTemplate) {
       leg->mPlatformSettings->baseTemplate = rawPlatformSettings->baseTemplate;
     }
     // Add originWaypoint shift to waypoint coordinates:
-    leg->mPlatformSettings->setPosition(
-      leg->mPlatformSettings->getPosition() + origin);
+    leg->mPlatformSettings->setPosition(leg->mPlatformSettings->getPosition() +
+                                        origin);
     // Cherry-picking of ScannerSettings
     std::unordered_set<std::string> templateFields;
     if (leg->mScannerSettings->baseTemplate != nullptr) {

--- a/src/assetloading/XmlSurveyLoader.cpp
+++ b/src/assetloading/XmlSurveyLoader.cpp
@@ -146,7 +146,7 @@ XmlSurveyLoader::createLegFromXML(
     legNode->FirstChildElement("platformSettings");
   if (platformSettingsNode != nullptr) {
     leg->mPlatformSettings =
-      createPlatformSettingsFromXml(platformSettingsNode);
+      createPlatformSettingsFromXml(platformSettingsNode, platformFields);
   }
 
   // Scanner settings
@@ -375,11 +375,67 @@ XmlSurveyLoader::loadLegs(tinyxml2::XMLElement* legNodes,
     std::unordered_set<std::string> platformFields;
     std::shared_ptr<Leg> leg(
       createLegFromXML(legNodes, &scannerFields, &platformFields));
-    // Add originWaypoint shift to waypoint coordinates:
-    if (leg->mPlatformSettings != nullptr /* && originWaypoint != null*/) {
-      leg->mPlatformSettings->setPosition(
-        leg->mPlatformSettings->getPosition() + origin);
+    // Cherry-picking of PlatformSettings
+    if (leg->mPlatformSettings == nullptr) {
+      leg->mPlatformSettings = std::make_shared<PlatformSettings>();
     }
+    std::shared_ptr<PlatformSettings> rawPlatformSettings =
+      leg->mPlatformSettings;
+    std::unordered_set<std::string> effectivePlatformFields = platformFields;
+    bool const hasCustomPlatformTemplate =
+      rawPlatformSettings->baseTemplate != nullptr &&
+      rawPlatformSettings->baseTemplate->id != defaultPlatformTemplate->id;
+    if (hasCustomPlatformTemplate) {
+      auto sameVec3 = [](glm::dvec3 const& a, glm::dvec3 const& b) -> bool {
+        return a.x == b.x && a.y == b.y && a.z == b.z;
+      };
+      auto sameRotation = [](Rotation const& a, Rotation const& b) -> bool {
+        return a.getQ0() == b.getQ0() && a.getQ1() == b.getQ1() &&
+               a.getQ2() == b.getQ2() && a.getQ3() == b.getQ3();
+      };
+
+      if (rawPlatformSettings->x != platformSettings->x)
+        effectivePlatformFields.insert("x");
+      if (rawPlatformSettings->y != platformSettings->y)
+        effectivePlatformFields.insert("y");
+      if (rawPlatformSettings->z != platformSettings->z)
+        effectivePlatformFields.insert("z");
+      if (rawPlatformSettings->yawAtDepartureSpecified !=
+          platformSettings->yawAtDepartureSpecified) {
+        effectivePlatformFields.insert("yawAtDepartureSpecified");
+      }
+      if (rawPlatformSettings->yawAtDeparture != platformSettings->yawAtDeparture)
+        effectivePlatformFields.insert("yawAtDeparture");
+      if (!sameVec3(rawPlatformSettings->relativeMountPosition,
+                    platformSettings->relativeMountPosition)) {
+        effectivePlatformFields.insert("relativeMountPosition");
+      }
+      if (!sameRotation(rawPlatformSettings->relativeMountAttitude,
+                        platformSettings->relativeMountAttitude)) {
+        effectivePlatformFields.insert("relativeMountAttitude");
+      }
+      if (rawPlatformSettings->onGround != platformSettings->onGround)
+        effectivePlatformFields.insert("onGround");
+      if (rawPlatformSettings->stopAndTurn != platformSettings->stopAndTurn)
+        effectivePlatformFields.insert("stopAndTurn");
+      if (rawPlatformSettings->smoothTurn != platformSettings->smoothTurn)
+        effectivePlatformFields.insert("smoothTurn");
+      if (rawPlatformSettings->slowdownEnabled !=
+          platformSettings->slowdownEnabled) {
+        effectivePlatformFields.insert("slowdownEnabled");
+      }
+      if (rawPlatformSettings->movePerSec_m != platformSettings->movePerSec_m)
+        effectivePlatformFields.insert("movePerSec_m");
+    }
+    effectivePlatformFields.erase("baseTemplate");
+    leg->mPlatformSettings =
+      platformSettings->cherryPick(rawPlatformSettings, effectivePlatformFields);
+    if (hasCustomPlatformTemplate) {
+      leg->mPlatformSettings->baseTemplate = rawPlatformSettings->baseTemplate;
+    }
+    // Add originWaypoint shift to waypoint coordinates:
+    leg->mPlatformSettings->setPosition(
+      leg->mPlatformSettings->getPosition() + origin);
     // Cherry-picking of ScannerSettings
     std::unordered_set<std::string> templateFields;
     if (leg->mScannerSettings->baseTemplate != nullptr) {

--- a/src/dataanalytics/HDA_StateJSONReporter.cpp
+++ b/src/dataanalytics/HDA_StateJSONReporter.cpp
@@ -558,6 +558,8 @@ HDA_StateJSONReporter::craftEntry(std::string const& key,
      << craftEntry("y", ps.y, d2) << craftEntry("z", ps.z, d2)
      << craftEntry("yawAtDepartureSpecified", ps.yawAtDepartureSpecified, d2)
      << craftEntry("yawAtDeparture", ps.yawAtDeparture, d2)
+     << craftEntry("relativeMountPosition", ps.relativeMountPosition, d2)
+     << craftEntry("relativeMountAttitude", ps.relativeMountAttitude, d2)
      << craftEntry("onGround", ps.onGround, d2)
      << craftEntry("stopAndTurn", ps.stopAndTurn, d2)
      << craftEntry("smoothTurn", ps.smoothTurn, d2)

--- a/src/platform/MovingPlatform.cpp
+++ b/src/platform/MovingPlatform.cpp
@@ -34,13 +34,20 @@ MovingPlatform::applySettings(std::shared_ptr<PlatformSettings> settings,
                               bool manual)
 {
   cfg_settings_movePerSec_m = settings->movePerSec_m;
+  onGround = settings->onGround;
   stopAndTurn = settings->stopAndTurn;
   smoothTurn = settings->smoothTurn;
   slowdownEnabled = settings->slowdownEnabled;
+  cfg_device_relativeMountPosition = settings->relativeMountPosition;
+  cfg_device_relativeMountAttitude = settings->relativeMountAttitude;
 
-  // Set platform position:
+  // Refresh absolute mount attitude cache before applying the leg position.
+  setAttitude(attitude);
+
   if (manual) {
     setPosition(settings->getPosition());
+  } else {
+    setPosition(position);
   }
 }
 

--- a/src/platform/Platform.cpp
+++ b/src/platform/Platform.cpp
@@ -68,6 +68,14 @@ Platform::applySettings(std::shared_ptr<PlatformSettings> settings, bool manual)
 {
   cfg_settings_movePerSec_m = settings->movePerSec_m;
   onGround = settings->onGround;
+  stopAndTurn = settings->stopAndTurn;
+  smoothTurn = settings->smoothTurn;
+  slowdownEnabled = settings->slowdownEnabled;
+  cfg_device_relativeMountPosition = settings->relativeMountPosition;
+  cfg_device_relativeMountAttitude = settings->relativeMountAttitude;
+
+  // Refresh absolute mount cache using the current platform attitude.
+  setAttitude(attitude);
 
   // Set platform position:
   setPosition(settings->getPosition());
@@ -80,6 +88,11 @@ Platform::retrieveCurrentSettings()
   // Settings from Platform
   settings->movePerSec_m = cfg_settings_movePerSec_m;
   settings->onGround = onGround;
+  settings->stopAndTurn = stopAndTurn;
+  settings->smoothTurn = smoothTurn;
+  settings->slowdownEnabled = slowdownEnabled;
+  settings->relativeMountPosition = cfg_device_relativeMountPosition;
+  settings->relativeMountAttitude = cfg_device_relativeMountAttitude;
   settings->setPosition(getPosition());
   // Return settings
   return settings;

--- a/src/platform/PlatformSettings.h
+++ b/src/platform/PlatformSettings.h
@@ -287,12 +287,10 @@ public:
        << "yawAtDepartureSpecified = " << yawAtDepartureSpecified << "\n"
        << "yawAtDeparture = " << yawAtDeparture << "\n"
        << "relativeMountPosition = (" << relativeMountPosition.x << ", "
-       << relativeMountPosition.y << ", " << relativeMountPosition.z
-       << ")\n"
+       << relativeMountPosition.y << ", " << relativeMountPosition.z << ")\n"
        << "relativeMountAttitude = (" << relativeMountAttitude.getQ0() << ", "
-       << relativeMountAttitude.getQ1() << ", "
-       << relativeMountAttitude.getQ2() << ", "
-       << relativeMountAttitude.getQ3() << ")\n"
+       << relativeMountAttitude.getQ1() << ", " << relativeMountAttitude.getQ2()
+       << ", " << relativeMountAttitude.getQ3() << ")\n"
        << "onGround = " << onGround << "\n"
        << "stopAndTurn = " << stopAndTurn << "\n"
        << "smoothTurn = " << smoothTurn << "\n"

--- a/src/platform/PlatformSettings.h
+++ b/src/platform/PlatformSettings.h
@@ -4,6 +4,8 @@
 
 #include <glm/glm.hpp>
 
+#include "maths/Rotation.h"
+
 #include <functional>
 #include <memory>
 #include <sstream>
@@ -48,6 +50,14 @@ public:
    * @brief Yaw angle (in radians) at platform departure
    */
   double yawAtDeparture = 0.0;
+  /**
+   * @brief Scanner mount position relative to the platform
+   */
+  glm::dvec3 relativeMountPosition = glm::dvec3(0, 0, 0);
+  /**
+   * @brief Scanner mount attitude relative to the platform
+   */
+  Rotation relativeMountAttitude = Rotation(glm::dvec3(1, 0, 0), 0);
 
   /**
    * @brief On ground flag
@@ -99,6 +109,8 @@ public:
     this->z = other->z;
     this->yawAtDepartureSpecified = other->yawAtDepartureSpecified;
     this->yawAtDeparture = other->yawAtDeparture;
+    this->relativeMountPosition = other->relativeMountPosition;
+    this->relativeMountAttitude = other->relativeMountAttitude;
     this->onGround = other->onGround;
     this->stopAndTurn = other->stopAndTurn;
     this->smoothTurn = other->smoothTurn;
@@ -149,6 +161,10 @@ public:
       settings->yawAtDepartureSpecified = cherries->yawAtDepartureSpecified;
     if (hasCherry("yawAtDeparture"))
       settings->yawAtDeparture = cherries->yawAtDeparture;
+    if (hasCherry("relativeMountPosition"))
+      settings->relativeMountPosition = cherries->relativeMountPosition;
+    if (hasCherry("relativeMountAttitude"))
+      settings->relativeMountAttitude = cherries->relativeMountAttitude;
     if (hasCherry("onGround"))
       settings->onGround = cherries->onGround;
     if (hasCherry("stopAndTurn"))
@@ -187,6 +203,32 @@ public:
     this->y = y;
     this->z = z;
   }
+  /**
+   * @brief Obtain scanner mount position relative to the platform
+   * @return Scanner mount position relative to the platform
+   */
+  glm::dvec3& getRelativeMountPosition() { return relativeMountPosition; }
+  /**
+   * @brief Set scanner mount position relative to the platform
+   * @param pos Scanner mount position relative to the platform
+   */
+  void setRelativeMountPosition(glm::dvec3 const& pos)
+  {
+    relativeMountPosition = pos;
+  }
+  /**
+   * @brief Obtain scanner mount attitude relative to the platform
+   * @return Scanner mount attitude relative to the platform
+   */
+  Rotation& getRelativeMountAttitude() { return relativeMountAttitude; }
+  /**
+   * @brief Set scanner mount attitude relative to the platform
+   * @param att Scanner mount attitude relative to the platform
+   */
+  void setRelativeMountAttitude(Rotation const& att)
+  {
+    relativeMountAttitude = att;
+  }
 
   /**
    * @brief Check if this PlatformSettings has an associated template (true)
@@ -223,6 +265,15 @@ public:
          << baseTemplate->yawAtDepartureSpecified << "\n"
          << "\ttemplate.yawAtDeparture = " << baseTemplate->yawAtDeparture
          << "\n"
+         << "\ttemplate.relativeMountPosition = ("
+         << baseTemplate->relativeMountPosition.x << ", "
+         << baseTemplate->relativeMountPosition.y << ", "
+         << baseTemplate->relativeMountPosition.z << ")\n"
+         << "\ttemplate.relativeMountAttitude = ("
+         << baseTemplate->relativeMountAttitude.getQ0() << ", "
+         << baseTemplate->relativeMountAttitude.getQ1() << ", "
+         << baseTemplate->relativeMountAttitude.getQ2() << ", "
+         << baseTemplate->relativeMountAttitude.getQ3() << ")\n"
          << "\ttemplate.onGround = " << baseTemplate->onGround << "\n"
          << "\ttemplate.stopAndTurn = " << baseTemplate->stopAndTurn << "\n"
          << "\ttemplate.smoothTurn = " << baseTemplate->smoothTurn << "\n"
@@ -235,6 +286,13 @@ public:
        << "z = " << z << "\n"
        << "yawAtDepartureSpecified = " << yawAtDepartureSpecified << "\n"
        << "yawAtDeparture = " << yawAtDeparture << "\n"
+       << "relativeMountPosition = (" << relativeMountPosition.x << ", "
+       << relativeMountPosition.y << ", " << relativeMountPosition.z
+       << ")\n"
+       << "relativeMountAttitude = (" << relativeMountAttitude.getQ0() << ", "
+       << relativeMountAttitude.getQ1() << ", "
+       << relativeMountAttitude.getQ2() << ", "
+       << relativeMountAttitude.getQ3() << ")\n"
        << "onGround = " << onGround << "\n"
        << "stopAndTurn = " << stopAndTurn << "\n"
        << "smoothTurn = " << smoothTurn << "\n"

--- a/src/pybinds/PyHelios.cpp
+++ b/src/pybinds/PyHelios.cpp
@@ -235,6 +235,26 @@ BOOST_PYTHON_MODULE(_pyhelios)
     .add_property("x", &PlatformSettings::x, &PlatformSettings::x)
     .add_property("y", &PlatformSettings::y, &PlatformSettings::y)
     .add_property("z", &PlatformSettings::z, &PlatformSettings::z)
+    .def("getRelativeMountPosition",
+         +[](PlatformSettings& ps) {
+           return new PythonDVec3(&ps.relativeMountPosition);
+         },
+         return_value_policy<manage_new_object>())
+    .def("getRelativeMountAttitude",
+         +[](PlatformSettings& ps) -> Rotation& {
+           return ps.relativeMountAttitude;
+         },
+         return_internal_reference<>())
+    .def("getScannerMountPosition",
+         +[](PlatformSettings& ps) {
+           return new PythonDVec3(&ps.relativeMountPosition);
+         },
+         return_value_policy<manage_new_object>())
+    .def("getScannerMountAttitude",
+         +[](PlatformSettings& ps) -> Rotation& {
+           return ps.relativeMountAttitude;
+         },
+         return_internal_reference<>())
     .add_property(
       "onGround", &PlatformSettings::onGround, &PlatformSettings::onGround)
     .add_property("stopAndTurn",

--- a/src/pybinds/PyHelios.cpp
+++ b/src/pybinds/PyHelios.cpp
@@ -235,26 +235,30 @@ BOOST_PYTHON_MODULE(_pyhelios)
     .add_property("x", &PlatformSettings::x, &PlatformSettings::x)
     .add_property("y", &PlatformSettings::y, &PlatformSettings::y)
     .add_property("z", &PlatformSettings::z, &PlatformSettings::z)
-    .def("getRelativeMountPosition",
-         +[](PlatformSettings& ps) {
-           return new PythonDVec3(&ps.relativeMountPosition);
-         },
-         return_value_policy<manage_new_object>())
-    .def("getRelativeMountAttitude",
-         +[](PlatformSettings& ps) -> Rotation& {
-           return ps.relativeMountAttitude;
-         },
-         return_internal_reference<>())
-    .def("getScannerMountPosition",
-         +[](PlatformSettings& ps) {
-           return new PythonDVec3(&ps.relativeMountPosition);
-         },
-         return_value_policy<manage_new_object>())
-    .def("getScannerMountAttitude",
-         +[](PlatformSettings& ps) -> Rotation& {
-           return ps.relativeMountAttitude;
-         },
-         return_internal_reference<>())
+    .def(
+      "getRelativeMountPosition",
+      +[](PlatformSettings& ps) {
+        return new PythonDVec3(&ps.relativeMountPosition);
+      },
+      return_value_policy<manage_new_object>())
+    .def(
+      "getRelativeMountAttitude",
+      +[](PlatformSettings& ps) -> Rotation& {
+        return ps.relativeMountAttitude;
+      },
+      return_internal_reference<>())
+    .def(
+      "getScannerMountPosition",
+      +[](PlatformSettings& ps) {
+        return new PythonDVec3(&ps.relativeMountPosition);
+      },
+      return_value_policy<manage_new_object>())
+    .def(
+      "getScannerMountAttitude",
+      +[](PlatformSettings& ps) -> Rotation& {
+        return ps.relativeMountAttitude;
+      },
+      return_internal_reference<>())
     .add_property(
       "onGround", &PlatformSettings::onGround, &PlatformSettings::onGround)
     .add_property("stopAndTurn",

--- a/src/pybinds/PyHeliosSimulation.cpp
+++ b/src/pybinds/PyHeliosSimulation.cpp
@@ -113,7 +113,12 @@ PyHeliosSimulation::newLeg(int index)
     index = n;
   std::shared_ptr<Leg> leg = std::make_shared<Leg>();
   leg->mScannerSettings = std::make_shared<ScannerSettings>();
-  leg->mPlatformSettings = std::make_shared<PlatformSettings>();
+  if (survey != nullptr && survey->scanner != nullptr &&
+      survey->scanner->platform != nullptr) {
+    leg->mPlatformSettings = survey->scanner->platform->retrieveCurrentSettings();
+  } else {
+    leg->mPlatformSettings = std::make_shared<PlatformSettings>();
+  }
   survey->addLeg(index, leg);
   return *leg;
 }

--- a/src/pybinds/PyHeliosSimulation.cpp
+++ b/src/pybinds/PyHeliosSimulation.cpp
@@ -115,7 +115,8 @@ PyHeliosSimulation::newLeg(int index)
   leg->mScannerSettings = std::make_shared<ScannerSettings>();
   if (survey != nullptr && survey->scanner != nullptr &&
       survey->scanner->platform != nullptr) {
-    leg->mPlatformSettings = survey->scanner->platform->retrieveCurrentSettings();
+    leg->mPlatformSettings =
+      survey->scanner->platform->retrieveCurrentSettings();
   } else {
     leg->mPlatformSettings = std::make_shared<PlatformSettings>();
   }


### PR DESCRIPTION
## Summary
- allow platformSettings templates and survey legs to define scannerMount overrides
- apply per-leg mount position and attitude through PlatformSettings and expose them in PyHelios
- add regression coverage for XML overrides and newLeg() mount defaults

Closes #839.