### PR TITLE
Add from_doi to Model base class

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -24,6 +24,7 @@ dependencies:
   - pybind11
   - pydantic
   - jsonschema
+  - pooch
   - python
   - scikit-build-core
   - setuptools_scm
@@ -40,7 +41,6 @@ dependencies:
   - lazrs-python
   - pandas
   - scipy
-  - pooch
   - tqdm
   - ninja
   - pytest-cov

--- a/python/helios/validation.py
+++ b/python/helios/validation.py
@@ -496,6 +496,62 @@ class Model(metaclass=ValidatedModelMetaClass):
 
     @classmethod
     @validate_call
+    def from_doi(cls, doi: str, filename: Optional[Path] = None):
+        """Load a model instance from a DOI-hosted serialized bundle.
+
+        Parameters
+        ----------
+        doi : str
+            DOI pointing to the serialized bundle contents.
+        filename : Optional[Path], optional
+            Relative path to the root YAML file within the DOI bundle. If omitted,
+            the class default serialization filename is used.
+
+        Returns
+        -------
+        Model
+            Deserialized instance of ``cls``.
+        """
+
+        import hashlib
+
+        try:
+            import pooch
+        except ImportError as exc:
+            raise ImportError(
+                "Model.from_doi requires the optional 'pooch' dependency."
+            ) from exc
+
+        normalized_doi = doi.removeprefix("doi:").strip()
+        if not normalized_doi:
+            raise ValueError("DOI must not be empty.")
+
+        if filename is None:
+            probe = object.__new__(cls)
+            root_filename = Path(cls._serialization_filename(probe))
+            if root_filename.suffix == "":
+                root_filename = Path(f"{root_filename}.helios.yaml")
+        else:
+            root_filename = filename.expanduser()
+            if root_filename.is_absolute():
+                raise ValueError(
+                    "DOI bundle filename must be relative to cache directory: "
+                    f"{root_filename}"
+                )
+
+        cache_key = hashlib.sha256(normalized_doi.encode("utf-8")).hexdigest()
+        cache_dir = Path(pooch.os_cache("helios")) / "doi" / cache_key
+        downloader = pooch.create(
+            path=cache_dir, base_url=f"doi:{normalized_doi}", registry=None
+        )
+        downloader.load_registry_from_doi()
+        for bundle_file in downloader.registry:
+            downloader.fetch(bundle_file)
+
+        return cls.from_bundle(cache_dir, filename=root_filename)
+
+    @classmethod
+    @validate_call
     def from_bundle(cls, path: Path, filename: Optional[Path] = None):
         """Load a model instance from a serialized bundle directory.
 

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -4,6 +4,7 @@ import shutil
 from pathlib import Path
 
 import numpy as np
+import pooch
 import pytest
 import yaml
 
@@ -294,6 +295,91 @@ def test_deserialize_model_from_yaml_rejects_non_instance_result(tmp_path, monke
         match="Expected YAML to deserialize into DynamicPlatformSettings, got list",
     ):
         serialization.deserialize_model_from_yaml(DynamicPlatformSettings, yaml_path)
+
+
+def test_from_doi_downloads_bundle_then_loads_root_yaml(tmp_path, monkeypatch):
+    source_bundle = tmp_path / "source_bundle"
+    source_bundle.mkdir()
+    root = DynamicPlatformSettings(
+        trajectory_settings=TrajectorySettings(
+            start_time=2.5, end_time=9.5, teleport_to_start=True
+        ),
+        speed_m_s=12.0,
+        x=4.0,
+        y=5.0,
+        z=6.0,
+    )
+    root.to_yaml(source_bundle, shallow=True)
+
+    cache_root = tmp_path / "cache_root"
+    created = {}
+    fetched = []
+
+    class FakePooch:
+        def __init__(self, path, base_url, registry=None):
+            self.path = Path(path)
+            self.base_url = base_url
+            self.registry = {} if registry is None else dict(registry)
+
+        def load_registry_from_doi(self):
+            self.registry = {
+                str(path.relative_to(source_bundle)).replace("\\", "/"): None
+                for path in source_bundle.rglob("*")
+                if path.is_file()
+            }
+
+        def fetch(self, fname, processor=None, downloader=None, progressbar=False):
+            fetched.append((fname, progressbar))
+            source = source_bundle / Path(fname)
+            target = self.path / Path(fname)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+            return str(target)
+
+    def _fake_create(
+        path,
+        base_url,
+        version=None,
+        version_dev="master",
+        env=None,
+        registry=None,
+        urls=None,
+        retry_if_failed=0,
+        allow_updates=True,
+    ):
+        created["path"] = Path(path)
+        created["base_url"] = base_url
+        return FakePooch(path=path, base_url=base_url, registry=registry)
+
+    monkeypatch.setattr(pooch, "os_cache", lambda _name: cache_root)
+    monkeypatch.setattr(pooch, "create", _fake_create)
+
+    loaded = DynamicPlatformSettings.from_doi("doi:10.5281/zenodo.1234567")
+
+    assert loaded.speed_m_s == 12.0
+    assert loaded.x == 4.0
+    assert loaded.y == 5.0
+    assert loaded.z == 6.0
+    assert loaded.trajectory_settings.start_time == 2.5
+    assert loaded.trajectory_settings.end_time == 9.5
+    assert loaded.trajectory_settings.teleport_to_start is True
+    assert created["base_url"] == "doi:10.5281/zenodo.1234567"
+    assert created["path"].parent == cache_root / "doi"
+    assert sorted(name for name, _ in fetched) == sorted(
+        str(path.relative_to(source_bundle)).replace("\\", "/")
+        for path in source_bundle.rglob("*")
+        if path.is_file()
+    )
+    assert all(progressbar is False for _, progressbar in fetched)
+
+
+def test_from_doi_rejects_absolute_bundle_filename(tmp_path):
+    with pytest.raises(
+        ValueError, match="DOI bundle filename must be relative to cache directory"
+    ):
+        SerializationRoot.from_doi(
+            "10.5281/zenodo.1234567", filename=tmp_path / "root.helios.yaml"
+        )
 
 
 def test_binary_deserialization_requires_existing_loader(tmp_path):


### PR DESCRIPTION
## Summary
- add `Model.from_doi(...)` in the shared base class to download DOI-hosted serialized bundles via `pooch` and load them through the existing YAML/bundle path
- add serialization tests covering DOI bundle downloads and DOI bundle filename validation
- treat `pooch` as a dependency in `environment-dev.yml`

Closes #816.
