### PR TITLE
Fix cmake usage of Boost::system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ add_library(helios)
 find_package(GDAL CONFIG REQUIRED)
 find_package(tinyxml2 REQUIRED)
 find_package(glm REQUIRED)
-find_package(Boost REQUIRED COMPONENTS system thread regex filesystem serialization iostreams random)
+find_package(Boost REQUIRED COMPONENTS thread regex filesystem serialization iostreams random)
 find_package(Armadillo REQUIRED)
 find_package(LAPACK REQUIRED)
 find_package(BLAS REQUIRED)
@@ -99,7 +99,7 @@ target_link_libraries(helios
     GDAL::GDAL
     tinyxml2::tinyxml2
     glm::glm
-    Boost::system
+    Boost::headers
     Boost::thread
     Boost::regex
     Boost::filesystem


### PR DESCRIPTION
Boost::system has been converted to header-only a long time ago. A library shim that we were relying on has been removed in 1.89. This commit removes usage of that shim and enables the transition to 1.90 in conda-forge.