### PR TITLE
Scene sharing between multiple surveys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ add_library(helios)
 find_package(GDAL CONFIG REQUIRED)
 find_package(tinyxml2 REQUIRED)
 find_package(glm REQUIRED)
-find_package(Boost REQUIRED COMPONENTS system thread regex filesystem iostreams random)
+find_package(Boost REQUIRED COMPONENTS thread regex filesystem iostreams random)
 find_package(Armadillo REQUIRED)
 find_package(LAPACK REQUIRED)
 find_package(BLAS REQUIRED)
@@ -108,7 +108,7 @@ target_link_libraries(helios
     GDAL::GDAL
     tinyxml2::tinyxml2
     glm::glm
-    Boost::system
+    Boost::headers
     Boost::thread
     Boost::regex
     Boost::filesystem

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,7 @@ target_compile_definitions(helios
 
 # Ensure Windows-specific compile options
 if(WIN32 OR MSVC)
-  target_compile_definitions(helios PUBLIC WIN32_LEAN_AND_MEAN _OS_WINDOWS_)
+  target_compile_definitions(helios PUBLIC WIN32_LEAN_AND_MEAN _OS_WINDOWS_ _USE_MATH_DEFINES)
   target_compile_options(helios PUBLIC /bigobj /EHsc)
 endif()
 

--- a/benchmarks/base_energy_model_compute_received_power_b.cpp
+++ b/benchmarks/base_energy_model_compute_received_power_b.cpp
@@ -100,10 +100,6 @@ private:
       );
 
     auto platform = std::make_shared<Platform>();
-    auto scene = std::make_shared<BenchmarkScene>();
-    scene->setBenchmarkAABB(glm::dvec3(-50.0, -50.0, -50.0),
-                            glm::dvec3(50.0, 50.0, 50.0));
-    platform->scene = scene;
     scanner->platform = platform;
 
     // Detector is required as computeReceivedPower reads detector rangeMin.

--- a/benchmarks/fullwaveform_compute_subrays_b.cpp
+++ b/benchmarks/fullwaveform_compute_subrays_b.cpp
@@ -53,6 +53,7 @@ public:
 
 struct BenchmarkContext
 {
+  std::shared_ptr<BenchmarkScene> scene;
   std::shared_ptr<SingleScanner> scanner;
   BenchmarkFullWaveformPulseRunnable runnable;
   UniformNoiseSource<double> intersectionNoise;
@@ -60,8 +61,9 @@ struct BenchmarkContext
   std::vector<RaySceneIntersection> intersections;
 
   explicit BenchmarkContext(int const beamSampleQuality)
-    : scanner(makeScanner(beamSampleQuality))
-    , runnable(scanner, makePulse())
+    : scene(makeScene())
+    , scanner(makeScanner(beamSampleQuality))
+    , runnable(scanner, *scene, makePulse())
     , intersectionNoise(0.0, 1.0)
   {
     runnable.detector = scanner->getDetector(0);
@@ -84,6 +86,14 @@ private:
                           1,                     // pulseNumber
                           static_cast<size_t>(0) // deviceIndex
     );
+  }
+
+  static std::shared_ptr<BenchmarkScene> makeScene()
+  {
+    auto scene = std::make_shared<BenchmarkScene>();
+    scene->setBenchmarkAABB(glm::dvec3(-25.0, -25.0, -25.0),
+                            glm::dvec3(-5.0, -5.0, -5.0));
+    return scene;
   }
 
   static std::shared_ptr<SingleScanner> makeScanner(int const beamSampleQuality)
@@ -111,10 +121,6 @@ private:
     scanner->getFWFSettings(0).beamSampleQuality = beamSampleQuality;
 
     auto platform = std::make_shared<Platform>();
-    auto scene = std::make_shared<BenchmarkScene>();
-    scene->setBenchmarkAABB(glm::dvec3(-25.0, -25.0, -25.0),
-                            glm::dvec3(-5.0, -5.0, -5.0));
-    platform->scene = scene;
     scanner->platform = platform;
 
     scanner->setDetector(

--- a/benchmarks/fullwaveform_digest_intersections_b.cpp
+++ b/benchmarks/fullwaveform_digest_intersections_b.cpp
@@ -51,6 +51,7 @@ public:
 
 struct BenchmarkContext
 {
+  std::shared_ptr<BenchmarkScene> scene;
   std::shared_ptr<SingleScanner> scanner;
   BenchmarkFullWaveformPulseRunnable runnable;
 
@@ -69,8 +70,9 @@ struct BenchmarkContext
 
   explicit BenchmarkContext(int const beamSampleQuality,
                             std::size_t const numReflections)
-    : scanner(makeScanner(beamSampleQuality))
-    , runnable(scanner, makePulse())
+    : scene(makeScene())
+    , scanner(makeScanner(beamSampleQuality))
+    , runnable(scanner, *scene, makePulse())
     , randGen1(1337)
     , randGen2(7331)
     , beamDir(0, 0, 0)
@@ -138,6 +140,14 @@ struct BenchmarkContext
     );
   }
 
+  static std::shared_ptr<BenchmarkScene> makeScene()
+  {
+    auto scene = std::make_shared<BenchmarkScene>();
+    scene->setBenchmarkAABB(glm::dvec3(-50.0, -50.0, -50.0),
+                            glm::dvec3(50.0, 50.0, 50.0));
+    return scene;
+  }
+
   static std::shared_ptr<SingleScanner> makeScanner(int const beamSampleQuality)
   {
     auto scanner =
@@ -163,10 +173,6 @@ struct BenchmarkContext
     scanner->getFWFSettings(0).beamSampleQuality = beamSampleQuality;
 
     auto platform = std::make_shared<Platform>();
-    auto scene = std::make_shared<BenchmarkScene>();
-    scene->setBenchmarkAABB(glm::dvec3(-50.0, -50.0, -50.0),
-                            glm::dvec3(50.0, 50.0, 50.0));
-    platform->scene = scene;
     scanner->platform = platform;
 
     scanner->setDetector(

--- a/benchmarks/fullwaveform_find_intersection_b.cpp
+++ b/benchmarks/fullwaveform_find_intersection_b.cpp
@@ -169,7 +169,7 @@ makeSparseCornerScene()
 }
 
 static std::shared_ptr<SingleScanner>
-makeScannerWithScene(std::shared_ptr<Scene> scene)
+makeScanner()
 {
   auto scanner =
     std::make_shared<SingleScanner>(0.0003,              // beamDiv_rad
@@ -192,7 +192,6 @@ makeScannerWithScene(std::shared_ptr<Scene> scene)
     );
 
   auto platform = std::make_shared<Platform>();
-  platform->scene = std::move(scene);
   scanner->platform = platform;
 
   scanner->setDetector(
@@ -208,6 +207,7 @@ makeScannerWithScene(std::shared_ptr<Scene> scene)
 
 struct BenchmarkContext
 {
+  std::shared_ptr<Scene> scene;
   std::shared_ptr<SingleScanner> scanner;
   BenchmarkFullWaveformPulseRunnable runnable;
   glm::dvec3 rayOrigin;
@@ -215,8 +215,9 @@ struct BenchmarkContext
   std::vector<double> tMinMax;
 
   explicit BenchmarkContext(std::size_t const gridResolution)
-    : scanner(makeScannerWithScene(makeTriangleGridScene(gridResolution)))
-    , runnable(scanner, makePulse(glm::dvec3(0.0, 0.0, 20.0)))
+    : scene(makeTriangleGridScene(gridResolution))
+    , scanner(makeScanner())
+    , runnable(scanner, *scene, makePulse(glm::dvec3(0.0, 0.0, 20.0)))
     , rayOrigin(0.0, 0.0, 20.0)
     , rayDir(0.0, 0.0, -1.0)
   {
@@ -225,8 +226,7 @@ struct BenchmarkContext
 
     // Precompute bbox intersection times so the benchmark isolates the
     // raycasting work in Scene::getIntersection.
-    tMinMax = scanner->platform->scene->getAABB()->getRayIntersection(rayOrigin,
-                                                                      rayDir);
+    tMinMax = scene->getAABB()->getRayIntersection(rayOrigin, rayDir);
 
     // If the ray misses the scene bbox, the benchmark would measure the fast
     // early-out path. That is not intended here.
@@ -239,6 +239,7 @@ struct BenchmarkContext
 
 struct MissBenchmarkContext
 {
+  std::shared_ptr<Scene> scene;
   std::shared_ptr<SingleScanner> scanner;
   BenchmarkFullWaveformPulseRunnable runnable;
   glm::dvec3 rayOrigin;
@@ -246,14 +247,14 @@ struct MissBenchmarkContext
   std::vector<double> tMinMax;
 
   MissBenchmarkContext()
-    : scanner(makeScannerWithScene(makeSparseCornerScene()))
-    , runnable(scanner, makePulse(glm::dvec3(0.0, 0.0, 20.0)))
+    : scene(makeSparseCornerScene())
+    , scanner(makeScanner())
+    , runnable(scanner, *scene, makePulse(glm::dvec3(0.0, 0.0, 20.0)))
     , rayOrigin(0.0, 0.0, 20.0)
     , rayDir(0.0, 0.0, -1.0)
   {
     runnable.detector = scanner->getDetector(0);
-    tMinMax = scanner->platform->scene->getAABB()->getRayIntersection(rayOrigin,
-                                                                      rayDir);
+    tMinMax = scene->getAABB()->getRayIntersection(rayOrigin, rayDir);
     if (tMinMax.empty()) {
       throw std::runtime_error(
         "Miss benchmark ray does not intersect the scene AABB");

--- a/benchmarks/macro_playback_b.cpp
+++ b/benchmarks/macro_playback_b.cpp
@@ -155,7 +155,7 @@ macro_playback_benchmark(benchmark::State& state)
   sc->fms = nullptr;
   playback->fms = nullptr;
   // Release main components
-  sc->platform->scene = nullptr;
+  playback->mSurvey->scene = nullptr;
   sc->platform = nullptr;
   playback->mSurvey->scanner = nullptr;
   playback->mSurvey = nullptr;

--- a/python/helios/helios_python.cpp
+++ b/python/helios/helios_python.cpp
@@ -989,10 +989,8 @@ PYBIND11_MODULE(_helios, m)
     [](Survey& s, std::shared_ptr<Platform> p) { s.scanner->platform = p; });
   survey.def_property(
     "scene",
-    [](const Survey& s) { return s.scanner->platform->scene; },
-    [](Survey& s, std::shared_ptr<Scene> sc) {
-      s.scanner->platform->scene = sc;
-    });
+    [](const Survey& s) { return s.scene; },
+    [](Survey& s, std::shared_ptr<Scene> sc) { s.scene = sc; });
 
   py::class_<Leg, std::shared_ptr<Leg>> leg(m, "Leg");
   leg.def(py::init<>())
@@ -1428,7 +1426,6 @@ PYBIND11_MODULE(_helios, m)
     .def_readwrite("attitude_x_noise_source", &Platform::attitudeXNoiseSource)
     .def_readwrite("attitude_y_noise_source", &Platform::attitudeYNoiseSource)
     .def_readwrite("attitude_z_noise_source", &Platform::attitudeZNoiseSource)
-    .def_readwrite("scene", &Platform::scene)
     .def_readwrite("target_waypoint", &Platform::targetWaypoint)
     .def_readwrite("origin_waypoint", &Platform::originWaypoint)
     .def_readwrite("next_waypoint", &Platform::nextWaypoint)
@@ -1786,7 +1783,8 @@ PYBIND11_MODULE(_helios, m)
          &Scanner::buildScanningPulseProcess,
          py::arg("parallelization_strategy"),
          py::arg("dropper"),
-         py::arg("pool"))
+         py::arg("pool"),
+         py::arg("scene"))
     .def("apply_settings",
          py::overload_cast<std::shared_ptr<ScannerSettings>>(
            &Scanner::applySettings))
@@ -1804,7 +1802,8 @@ PYBIND11_MODULE(_helios, m)
     .def("do_sim_step",
          &Scanner::doSimStep,
          py::arg("legIndex"),
-         py::arg("currentGpsTime"))
+         py::arg("currentGpsTime"),
+         py::arg("scene"))
     .def("to_string", &Scanner::toString)
     .def("calc_rays_number", py::overload_cast<>(&Scanner::calcRaysNumber))
     .def("calc_rays_number",
@@ -2402,7 +2401,8 @@ PYBIND11_MODULE(_helios, m)
     .def("do_sim_step",
          &SingleScanner::doSimStep,
          py::arg("leg_index"),
-         py::arg("current_gps_time"))
+         py::arg("current_gps_time"),
+         py::arg("scene"))
     .def("calc_rays_number", &SingleScanner::calcRaysNumber, py::arg("idx") = 0)
     .def("prepare_discretization",
          &SingleScanner::prepareDiscretization,
@@ -2651,7 +2651,8 @@ PYBIND11_MODULE(_helios, m)
     .def("do_sim_step",
          &MultiScanner::doSimStep,
          py::arg("leg_index"),
-         py::arg("current_gps_time"))
+         py::arg("current_gps_time"),
+         py::arg("scene"))
     .def("calc_rays_number", &MultiScanner::calcRaysNumber, py::arg("idx"))
     .def("prepare_discretization",
          &MultiScanner::prepareDiscretization,
@@ -3109,7 +3110,9 @@ PYBIND11_MODULE(_helios, m)
   py::class_<ScanningPulseProcess,
              ScanningPulseProcessWrap,
              std::shared_ptr<ScanningPulseProcess>>(m, "ScanningPulseProcess")
-    .def(py::init<std::shared_ptr<Scanner>>())
+    .def(py::init<std::shared_ptr<Scanner>, Scene&>(),
+         py::arg("scanner"),
+         py::arg("scene"))
     .def("handle_pulse_computation",
          &ScanningPulseProcess::handlePulseComputation)
     .def("on_leg_complete", &ScanningPulseProcess::onLegComplete)
@@ -3130,6 +3133,7 @@ PYBIND11_MODULE(_helios, m)
              std::shared_ptr<BuddingScanningPulseProcess>>(
     m, "BuddingScanningPulseProcess")
     .def(py::init<std::shared_ptr<Scanner>,
+                  Scene&,
                   PulseTaskDropper&,
                   PulseThreadPool&,
                   RandomnessGenerator<double>&,
@@ -3141,6 +3145,7 @@ PYBIND11_MODULE(_helios, m)
 #endif
                   >(),
          py::arg("scanner"),
+         py::arg("scene"),
          py::arg("dropper"),
          py::arg("pool"),
          py::arg("randGen1"),
@@ -3163,6 +3168,7 @@ PYBIND11_MODULE(_helios, m)
              std::shared_ptr<WarehouseScanningPulseProcess>>(
     m, "WarehouseScanningPulseProcess")
     .def(py::init<std::shared_ptr<Scanner>,
+                  Scene&,
                   PulseTaskDropper&,
                   PulseWarehouseThreadPool&,
                   RandomnessGenerator<double>&,
@@ -3174,6 +3180,7 @@ PYBIND11_MODULE(_helios, m)
 #endif
                   >(),
          py::arg("scanner"),
+         py::arg("scene"),
          py::arg("dropper"),
          py::arg("pool"),
          py::arg("randGen1"),

--- a/src/assetloading/XmlAssetsLoader.cpp
+++ b/src/assetloading/XmlAssetsLoader.cpp
@@ -5,7 +5,6 @@
 
 #include <adt/exprtree/UnivarExprTreeNode.h>
 
-#define _USE_MATH_DEFINES
 #include <cmath>
 #include <sstream>
 #include <vector>

--- a/src/assetloading/XmlSurveyLoader.cpp
+++ b/src/assetloading/XmlSurveyLoader.cpp
@@ -72,7 +72,7 @@ XmlSurveyLoader::createSurveyFromXml(tinyxml2::XMLElement* surveyNode,
   // Load scene
   std::string sceneString = surveyNode->Attribute("scene");
   try {
-    survey->scanner->platform->scene = loadScene(sceneString);
+    survey->setScene(loadScene(sceneString));
   } catch (const std::exception& e) {
     std::stringstream ss;
     ss << "Failed to load scene '" << sceneString << "': " << e.what();
@@ -82,13 +82,12 @@ XmlSurveyLoader::createSurveyFromXml(tinyxml2::XMLElement* surveyNode,
   SpectralLibrary spectralLibrary = SpectralLibrary(
     (float)survey->scanner->getWavelength(), assetsDir, "spectra");
   spectralLibrary.readReflectances();
-  spectralLibrary.setReflectances(survey->scanner->platform->scene.get());
-  survey->scanner->platform->scene->setDefaultReflectance(
+  spectralLibrary.setReflectances(survey->getScene().get());
+  survey->requireScene().setDefaultReflectance(
     spectralLibrary.getDefaultReflectance());
 
   // Update materials for all swap on repeat handlers
-  for (std::shared_ptr<ScenePart> sp :
-       survey->scanner->platform->scene->parts) {
+  for (std::shared_ptr<ScenePart> sp : survey->requireScene().parts) {
     // Ignore scene parts with no swap on repeat
     if (sp->sorh == nullptr)
       continue;
@@ -446,7 +445,7 @@ XmlSurveyLoader::applySceneShift(tinyxml2::XMLElement* surveyNode,
                                  std::shared_ptr<Survey> survey)
 {
   // Obtain scene shift
-  glm::dvec3 shift = survey->scanner->platform->scene->getShift();
+  glm::dvec3 shift = survey->requireScene().getShift();
   // Prepare normal distribution if necessary
   RandomnessGenerator<double> rg(*DEFAULT_RG);
   bool legRandomOffset = surveyNode->BoolAttribute("legRandomOffset", false);
@@ -484,8 +483,7 @@ XmlSurveyLoader::applySceneShift(tinyxml2::XMLElement* surveyNode,
       // If specified, move waypoint z coordinate to ground level
       if (leg->mPlatformSettings->onGround) {
         glm::dvec3 pos = leg->mPlatformSettings->getPosition();
-        glm::dvec3 ground =
-          survey->scanner->platform->scene->getGroundPointAt(pos);
+        glm::dvec3 ground = survey->requireScene().getGroundPointAt(pos);
         leg->mPlatformSettings->setPosition(glm::dvec3(pos.x, pos.y, ground.z));
       }
 

--- a/src/dataanalytics/HDA_StateJSONReporter.cpp
+++ b/src/dataanalytics/HDA_StateJSONReporter.cpp
@@ -284,7 +284,7 @@ HDA_StateJSONReporter::reportDetector()
 void
 HDA_StateJSONReporter::reportScene()
 {
-  Scene* sc = sp->mScanner->platform->scene.get();
+  Scene* sc = sp->mSurvey->scene.get();
   std::stringstream ss;
   ss << openEntry("scene", 3, EntryType::OBJECT)
      << craftEntry("bbox_min", sc->getBBox()->getMin(), 4)

--- a/src/demo/DynamicSceneDemo.cpp
+++ b/src/demo/DynamicSceneDemo.cpp
@@ -98,7 +98,7 @@ DynamicSceneDemo::buildCanvas(shared_ptr<Survey> survey)
 
   // Assuming the scene is already dynamic, try to cast it
   try {
-    DynScene& ds = dynamic_cast<DynScene&>(*survey->scanner->platform->scene);
+    DynScene& ds = dynamic_cast<DynScene&>(*survey->scene);
     canvas = make_shared<VHSceneCanvas>(ds,
                                         canvasTitle,
                                         normalsKeyboardCallback,
@@ -110,8 +110,8 @@ DynamicSceneDemo::buildCanvas(shared_ptr<Survey> survey)
   catch (std::bad_cast& bcex) {
     std::cout << "DynamicSceneDemo received a non dynamic scene but a "
               << "basic one. In consequence, it was wrapped." << std::endl;
-    dsWrapper = make_shared<DynScene>(
-      *static_pointer_cast<StaticScene>(survey->scanner->platform->scene));
+    dsWrapper =
+      make_shared<DynScene>(*static_pointer_cast<StaticScene>(survey->scene));
     canvas = make_shared<VHSceneCanvas>(*dsWrapper,
                                         canvasTitle,
                                         normalsKeyboardCallback,

--- a/src/demo/RaycastingDemo.cpp
+++ b/src/demo/RaycastingDemo.cpp
@@ -52,7 +52,7 @@ RaycastingDemo::buildCanvas(shared_ptr<Survey> survey)
 
   // Assuming the scene is already dynamic, try to cast it
   try {
-    DynScene& ds = dynamic_cast<DynScene&>(*survey->scanner->platform->scene);
+    DynScene& ds = dynamic_cast<DynScene&>(*survey->scene);
     canvas = make_shared<VHRaycastingCanvas>(ds,
                                              *survey->scanner,
                                              *survey,
@@ -66,8 +66,8 @@ RaycastingDemo::buildCanvas(shared_ptr<Survey> survey)
   catch (std::bad_cast& bcex) {
     std::cout << "RaycastingDemo received a non dynamic scene but a "
               << "basic one. In consequence, it was wrapped." << std::endl;
-    dsWrapper = make_shared<DynScene>(
-      *static_pointer_cast<StaticScene>(survey->scanner->platform->scene));
+    dsWrapper =
+      make_shared<DynScene>(*static_pointer_cast<StaticScene>(survey->scene));
     canvas = make_shared<VHRaycastingCanvas>(*dsWrapper,
                                              *survey->scanner,
                                              *survey,

--- a/src/filems/factory/FMSFacadeFactory.cpp
+++ b/src/filems/factory/FMSFacadeFactory.cpp
@@ -76,6 +76,8 @@ helios::filems::FMSFacadeFactory::buildFacade(std::string const& outdir,
       std::make_shared<VectorialMeasurementWriter>());
   }
   fmsWrite.getMeasurementWriter()->setScanner(survey.scanner);
+  fmsWrite.getMeasurementWriter()->setSceneShift(
+    survey.requireScene().getShift());
   fmsWrite.setMeasurementWriterLasOutput(lasOutput);
   fmsWrite.setMeasurementWriterLas10(las10);
   fmsWrite.setMeasurementWriterZipOutput(zipOutput);

--- a/src/filems/write/core/BaseMeasurementWriter.h
+++ b/src/filems/write/core/BaseMeasurementWriter.h
@@ -137,10 +137,13 @@ public:
   inline void setScanner(std::shared_ptr<Scanner> scanner)
   {
     this->scanner = scanner;
-    if (scanner != nullptr) {
-      this->shift = this->scanner->platform->scene->getShift();
-    }
   }
+  /**
+   * @brief Set the shift applied by the base measurement writer
+   * @param shift New scene shift
+   * @see filems::BaseMeasurementWriter::shift
+   */
+  inline void setSceneShift(glm::dvec3 const& shift) { this->shift = shift; }
   /**
    * @brief Obtain the shift applied by the base measurement writer
    * @see filems::BaseMeasurementWriter::shift

--- a/src/main/LidarSim.cpp
+++ b/src/main/LidarSim.cpp
@@ -159,7 +159,7 @@ LidarSim::release(std::shared_ptr<SurveyPlayback> sp)
   sc->fms = nullptr;
   sp->fms = nullptr;
   // Release main components
-  sc->platform->scene = nullptr;
+  sp->mSurvey->scene = nullptr;
   sc->platform = nullptr;
   sp->mSurvey->scanner = nullptr;
   sp->mSurvey = nullptr;

--- a/src/maths/MathConstants.h
+++ b/src/maths/MathConstants.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 
 /**

--- a/src/platform/GroundVehiclePlatform.cpp
+++ b/src/platform/GroundVehiclePlatform.cpp
@@ -1,4 +1,5 @@
 #include "GroundVehiclePlatform.h"
+#include <logging.hpp>
 
 using namespace std;
 

--- a/src/platform/GroundVehiclePlatform.h
+++ b/src/platform/GroundVehiclePlatform.h
@@ -2,7 +2,6 @@
 
 #include "SimplePhysicsPlatform.h"
 
-#define _USE_MATH_DEFINES
 #include "math.h"
 
 /**

--- a/src/platform/HelicopterPlatform.cpp
+++ b/src/platform/HelicopterPlatform.cpp
@@ -1,4 +1,5 @@
 #include "HelicopterPlatform.h"
+#include <logging.hpp>
 
 #include "maths/Directions.h"
 

--- a/src/platform/HelicopterPlatform.h
+++ b/src/platform/HelicopterPlatform.h
@@ -6,6 +6,8 @@
 
 #include "maths/Rotation.h"
 
+#include <cmath>
+
 /**
  * @brief Class representing a helicopter platform
  */

--- a/src/platform/InterpolatedMovingPlatform.cpp
+++ b/src/platform/InterpolatedMovingPlatform.cpp
@@ -1,3 +1,4 @@
+#include <logging.hpp>
 #include <maths/Directions.h>
 #include <platform/InterpolatedMovingPlatform.h>
 #include <platform/trajectory/DesignTrajectoryFunction.h>

--- a/src/platform/InterpolatedMovingPlatformEgg.h
+++ b/src/platform/InterpolatedMovingPlatformEgg.h
@@ -101,7 +101,6 @@ protected:
     imp.cfg_device_relativeMountAttitude = cfg_device_relativeMountAttitude;
     imp.lastCheckZ = lastCheckZ;
     imp.lastGroundCheck = lastGroundCheck;
-    imp.scene = scene;
     imp.positionXNoiseSource = positionXNoiseSource;
     imp.positionYNoiseSource = positionYNoiseSource;
     imp.positionZNoiseSource = positionZNoiseSource;

--- a/src/platform/MovingPlatform.cpp
+++ b/src/platform/MovingPlatform.cpp
@@ -8,6 +8,7 @@
 
 #include "MovingPlatform.h"
 #include "PrintUtils.h"
+#include <logging.hpp>
 using namespace std;
 
 // ***  CONSTRUCTION / DESTRUCTION  *** //

--- a/src/platform/Platform.cpp
+++ b/src/platform/Platform.cpp
@@ -24,7 +24,6 @@ Platform::_clone(std::shared_ptr<Platform> p)
     Rotation(this->cfg_device_relativeMountAttitude);
   p->lastCheckZ = this->lastCheckZ;
   p->lastGroundCheck = glm::dvec3(this->lastGroundCheck);
-  p->scene = scene;
 
   p->positionXNoiseSource = this->positionXNoiseSource;
   p->positionYNoiseSource = this->positionYNoiseSource;

--- a/src/platform/Platform.h
+++ b/src/platform/Platform.h
@@ -7,7 +7,6 @@
 #include "Asset.h"
 #include "Directions.h"
 #include "PlatformSettings.h"
-#include "Scene.h"
 #include "maths/Rotation.h"
 #include <NoiseSource.h>
 
@@ -38,11 +37,6 @@ public:
    * @brief Not used at the moment. Might be removed in the future.
    */
   glm::dvec3 lastGroundCheck = glm::dvec3(0, 0, 0);
-  /**
-   * @brief Scene where the platform belongs to
-   */
-  std::shared_ptr<Scene> scene = nullptr;
-
   // Noise generators
   /**
    * @brief Noise source for x component of platform position

--- a/src/platform/SimplePhysicsPlatform.cpp
+++ b/src/platform/SimplePhysicsPlatform.cpp
@@ -1,4 +1,5 @@
 #include "SimplePhysicsPlatform.h"
+#include <logging.hpp>
 
 // ***  CONSTRUCTION / DESTRUCTION  *** //
 // ************************************ //

--- a/src/python/PyHeliosSimulation.cpp
+++ b/src/python/PyHeliosSimulation.cpp
@@ -60,22 +60,14 @@ PyHeliosSimulation::~PyHeliosSimulation()
   if (survey != nullptr) {
     // Release shared resources
     bool sharedDetector = false;
-    bool sharedScene = false;
     std::shared_ptr<AbstractDetector> ad = survey->scanner->getDetector();
-    std::shared_ptr<Scene> scene = survey->scanner->platform->scene;
     for (PyHeliosSimulation* copy : copies) {
       if (copy->survey->scanner->getDetector() == ad) {
         sharedDetector = true;
       }
-      if (copy->survey->scanner->platform->scene == scene) {
-        sharedScene = true;
-      }
     }
     if (!sharedDetector) {
       survey->scanner->getDetector()->shutdown();
-    }
-    if (!sharedScene) {
-      survey->scanner->platform->scene->shutdown();
     }
     // Update copy tracking for non-destroyed copies
     for (PyHeliosSimulation* copy : copies) {
@@ -413,8 +405,7 @@ std::shared_ptr<DynScene>
 PyHeliosSimulation::_getDynScene()
 {
   try {
-    return std::dynamic_pointer_cast<DynScene>(
-      survey->scanner->platform->scene);
+    return std::dynamic_pointer_cast<DynScene>(survey->scene);
   } catch (std::exception& ex) {
     throw HeliosException(
       "Failed to obtain dynamic scene. Current scene is not dynamic.");

--- a/src/python/PyHeliosSimulation.h
+++ b/src/python/PyHeliosSimulation.h
@@ -161,7 +161,7 @@ public:
    * @return Platform used by the simulation
    */
   Platform* getPlatform() { return survey->scanner->platform.get(); }
-  Scene* getScene() { return survey->scanner->platform->scene.get(); }
+  Scene* getScene() { return survey->scene.get(); }
   /**
    * @brief Obtain the number of legs
    *

--- a/src/python/ScannerWrap.h
+++ b/src/python/ScannerWrap.h
@@ -92,9 +92,12 @@ public:
     PYBIND11_OVERLOAD_PURE(void, Scanner, applySettingsFWF, fwfSettings, idx);
   }
 
-  void doSimStep(unsigned int legIndex, double const currentGpsTime) override
+  void doSimStep(unsigned int legIndex,
+                 double const currentGpsTime,
+                 Scene& scene) override
   {
-    PYBIND11_OVERLOAD_PURE(void, Scanner, doSimStep, legIndex, currentGpsTime);
+    PYBIND11_OVERLOAD_PURE(
+      void, Scanner, doSimStep, legIndex, currentGpsTime, scene);
   }
 
   void calcRaysNumber(size_t const idx) override

--- a/src/python/SceneHandling.cpp
+++ b/src/python/SceneHandling.cpp
@@ -380,7 +380,8 @@ makeInterpolatedShift(Survey& survey,
 void
 makeSceneShift(Survey& survey)
 {
-  glm::dvec3 shift = survey.scanner->platform->scene->getShift();
+  Scene& scene = survey.requireScene();
+  glm::dvec3 shift = scene.getShift();
   // Apply changes to interpolated charachteristics, if any
   if (auto ip = std::dynamic_pointer_cast<InterpolatedMovingPlatformEgg>(
         survey.scanner->platform)) {
@@ -396,8 +397,7 @@ makeSceneShift(Survey& survey)
       platformPos -= shift;
       // If specified, move waypoint z coordinate to ground level
       if (leg.mPlatformSettings->onGround) {
-        auto groundZ =
-          survey.scanner->platform->scene->getGroundPointAt(platformPos).z;
+        auto groundZ = scene.getGroundPointAt(platformPos).z;
         platformPos.z = groundZ;
       }
       leg.mPlatformSettings->setPosition(platformPos);

--- a/src/scanner/BuddingScanningPulseProcess.cpp
+++ b/src/scanner/BuddingScanningPulseProcess.cpp
@@ -5,6 +5,7 @@
 // ************************************ //
 BuddingScanningPulseProcess::BuddingScanningPulseProcess(
   std::shared_ptr<Scanner> scanner,
+  Scene& scene,
   PulseTaskDropper& dropper,
   PulseThreadPool& pool,
   RandomnessGenerator<double>& randGen1,
@@ -15,7 +16,7 @@ BuddingScanningPulseProcess::BuddingScanningPulseProcess(
   std::shared_ptr<HDA_PulseRecorder> pulseRecorder
 #endif
   )
-  : ScanningPulseProcess(scanner)
+  : ScanningPulseProcess(scanner, scene)
   , dropper(dropper)
   , pool(pool)
   , randGen1(randGen1)

--- a/src/scanner/BuddingScanningPulseProcess.h
+++ b/src/scanner/BuddingScanningPulseProcess.h
@@ -113,6 +113,7 @@ public:
    */
   BuddingScanningPulseProcess(
     std::shared_ptr<Scanner> scanner,
+    Scene& scene,
     PulseTaskDropper& dropper,
     PulseThreadPool& pool,
     RandomnessGenerator<double>& randGen1,

--- a/src/scanner/EvalScannerHead.cpp
+++ b/src/scanner/EvalScannerHead.cpp
@@ -1,6 +1,5 @@
 #include <scanner/EvalScannerHead.h>
 
-#define _USE_MATH_DEFINES
 #include <MathConstants.h>
 #include <math.h>
 #include <maths/TrigoTricks.h>

--- a/src/scanner/MultiScanner.cpp
+++ b/src/scanner/MultiScanner.cpp
@@ -104,7 +104,9 @@ MultiScanner::applySettings(std::shared_ptr<ScannerSettings> settings,
 }
 
 void
-MultiScanner::doSimStep(unsigned int legIndex, double const currentGpsTime)
+MultiScanner::doSimStep(unsigned int legIndex,
+                        double const currentGpsTime,
+                        Scene& scene)
 {
   // Check whether the scanner is active or not
   bool const _isActive = isActive();
@@ -134,7 +136,7 @@ MultiScanner::doSimStep(unsigned int legIndex, double const currentGpsTime)
     return;
 
   // Handle trajectory output
-  handleTrajectoryOutput(currentGpsTime);
+  handleTrajectoryOutput(currentGpsTime, scene);
 }
 
 void

--- a/src/scanner/MultiScanner.h
+++ b/src/scanner/MultiScanner.h
@@ -107,7 +107,9 @@ public:
   /**
    * @see Scanner::doSimStep(unsigned int, double const)
    */
-  void doSimStep(unsigned int legIndex, double const currentGpsTime) override;
+  void doSimStep(unsigned int legIndex,
+                 double const currentGpsTime,
+                 Scene& scene) override;
   /**
    * @see Scanner::calcRaysNumber(size_t const)
    */

--- a/src/scanner/Scanner.cpp
+++ b/src/scanner/Scanner.cpp
@@ -15,6 +15,7 @@
 #include <Trajectory.h>
 #include <scanner/BuddingScanningPulseProcess.h>
 #include <scanner/WarehouseScanningPulseProcess.h>
+#include <scene/Scene.h>
 
 using namespace std;
 
@@ -281,7 +282,7 @@ Scanner::handleSimStepNoise(glm::dvec3& absoluteBeamOrigin,
 }
 
 void
-Scanner::handleTrajectoryOutput(double const currentGpsTime)
+Scanner::handleTrajectoryOutput(double const currentGpsTime, Scene& scene)
 {
   // Get out of here if trajectory time interval is 0 (no trajectory output)
   if (trajectoryTimeInterval_ns == 0.0)
@@ -296,7 +297,7 @@ Scanner::handleTrajectoryOutput(double const currentGpsTime)
   lastTrajectoryTime = currentGpsTime;
 
   // Compute shifted position
-  glm::dvec3 const pos = platform->position + platform->scene->getShift();
+  glm::dvec3 const pos = platform->position + scene.getShift();
 
   // Obtain roll, pitch and yaw
   double roll, pitch, yaw;
@@ -352,11 +353,13 @@ void
 Scanner::buildScanningPulseProcess(
   int const parallelizationStrategy,
   PulseTaskDropper& dropper,
-  std::shared_ptr<PulseThreadPoolInterface> pool)
+  std::shared_ptr<PulseThreadPoolInterface> pool,
+  Scene& scene)
 {
   if (parallelizationStrategy == 0) {
     spp = std::unique_ptr<ScanningPulseProcess>(new BuddingScanningPulseProcess(
       getDetector(0)->scanner,
+      scene,
       dropper,
       *(std::static_pointer_cast<PulseThreadPool>(pool)),
       *randGen1,
@@ -371,6 +374,7 @@ Scanner::buildScanningPulseProcess(
     spp =
       std::unique_ptr<ScanningPulseProcess>(new WarehouseScanningPulseProcess(
         getDetector(0)->scanner,
+        scene,
         dropper,
         *(std::static_pointer_cast<PulseWarehouseThreadPool>(pool)),
         *randGen1,

--- a/src/scanner/Scanner.cpp
+++ b/src/scanner/Scanner.cpp
@@ -5,7 +5,6 @@
 
 #include <iostream>
 
-#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include <logging.hpp>

--- a/src/scanner/Scanner.h
+++ b/src/scanner/Scanner.h
@@ -7,6 +7,7 @@
 #include <ScannerHead.h>
 #include <ScanningDevice.h>
 class AbstractDetector;
+class Scene;
 #include <FWFSettings.h>
 #include <Platform.h>
 #include <RandomnessGenerator.h>
@@ -218,10 +219,10 @@ public:
    * @see Simulation::taskDropper
    * @see Simulation::threadPool
    */
-  void buildScanningPulseProcess(
-    int const parallelizationStrategy,
-    PulseTaskDropper& dropper,
-    std::shared_ptr<PulseThreadPoolInterface> pool);
+  void buildScanningPulseProcess(int const parallelizationStrategy,
+                                 PulseTaskDropper& dropper,
+                                 std::shared_ptr<PulseThreadPoolInterface> pool,
+                                 Scene& scene);
   /**
    * @brief Apply scanner settings
    * @param settings Scanner settings to be applied
@@ -282,7 +283,8 @@ public:
    * @param currentGpsTime GPS time of current pulse
    */
   virtual void doSimStep(unsigned int legIndex,
-                         double const currentGpsTime) = 0;
+                         double const currentGpsTime,
+                         Scene& scene) = 0;
   /**
    * @brief Build a string representation of the scanner
    * @return String representing the scanner
@@ -493,7 +495,7 @@ public:
    * @param currentGpsTime Current GPS time (nanoseconds)
    * @see Scanner::allTrajectories
    */
-  void handleTrajectoryOutput(double const currentGpsTime);
+  void handleTrajectoryOutput(double const currentGpsTime, Scene& scene);
   /**
    * @brief Track given output path in a thread safe way
    * @param path Output path to be tracked

--- a/src/scanner/ScannerHead.cpp
+++ b/src/scanner/ScannerHead.cpp
@@ -1,6 +1,5 @@
 #include "ScannerHead.h"
 
-#define _USE_MATH_DEFINES
 #include <MathConstants.h>
 #include <math.h>
 

--- a/src/scanner/ScanningPulseProcess.cpp
+++ b/src/scanner/ScanningPulseProcess.cpp
@@ -3,8 +3,9 @@
 
 // ***  CONSTRUCTION / DESTRUCTION  *** //
 // ************************************ //
-ScanningPulseProcess::ScanningPulseProcess(std::shared_ptr<Scanner> scanner)
-  : ptf(*(scanner->platform->scene))
+ScanningPulseProcess::ScanningPulseProcess(std::shared_ptr<Scanner> scanner,
+                                           Scene& scene)
+  : ptf(scene)
   , scanner(scanner)
 {
 }

--- a/src/scanner/ScanningPulseProcess.h
+++ b/src/scanner/ScanningPulseProcess.h
@@ -5,6 +5,7 @@
 #include <Rotation.h>
 #include <scanner/SimulatedPulse.h>
 class Scanner;
+class Scene;
 
 #include <glm/glm.hpp>
 
@@ -37,7 +38,7 @@ public:
   /**
    * @brief Default constructor for scanning pulse process
    */
-  ScanningPulseProcess(std::shared_ptr<Scanner> scanner);
+  ScanningPulseProcess(std::shared_ptr<Scanner> scanner, Scene& scene);
   virtual ~ScanningPulseProcess() = default;
 
   // ***  PULSE COMPUTATION  *** //

--- a/src/scanner/SingleScanner.cpp
+++ b/src/scanner/SingleScanner.cpp
@@ -138,7 +138,9 @@ SingleScanner::applySettings(std::shared_ptr<ScannerSettings> settings,
 }
 
 void
-SingleScanner::doSimStep(unsigned int legIndex, double const currentGpsTime)
+SingleScanner::doSimStep(unsigned int legIndex,
+                         double const currentGpsTime,
+                         Scene& scene)
 {
   // Check whether the scanner is active or not
   bool const _isActive = isActive();
@@ -161,7 +163,7 @@ SingleScanner::doSimStep(unsigned int legIndex, double const currentGpsTime)
     return;
 
   // Handle trajectory output
-  handleTrajectoryOutput(currentGpsTime);
+  handleTrajectoryOutput(currentGpsTime, scene);
 }
 
 void

--- a/src/scanner/SingleScanner.h
+++ b/src/scanner/SingleScanner.h
@@ -87,7 +87,9 @@ public:
   /**
    * @see Scanner::doSimStep(unsigned int, double const)
    */
-  void doSimStep(unsigned int legIndex, double const currentGpsTime) override;
+  void doSimStep(unsigned int legIndex,
+                 double const currentGpsTime,
+                 Scene& scene) override;
   /**
    * @see Scanner::calcRaysNumber(size_t const)
    */

--- a/src/scanner/WarehouseScanningPulseProcess.cpp
+++ b/src/scanner/WarehouseScanningPulseProcess.cpp
@@ -5,6 +5,7 @@
 // ************************************ //
 WarehouseScanningPulseProcess::WarehouseScanningPulseProcess(
   std::shared_ptr<Scanner> scanner,
+  Scene& scene,
   PulseTaskDropper& dropper,
   PulseWarehouseThreadPool& pool,
   RandomnessGenerator<double>& randGen1,
@@ -15,7 +16,7 @@ WarehouseScanningPulseProcess::WarehouseScanningPulseProcess(
   std::shared_ptr<HDA_PulseRecorder> pulseRecorder
 #endif
   )
-  : ScanningPulseProcess(scanner)
+  : ScanningPulseProcess(scanner, scene)
   , dropper(dropper)
   , pool(pool)
   , randGen1(randGen1)

--- a/src/scanner/WarehouseScanningPulseProcess.h
+++ b/src/scanner/WarehouseScanningPulseProcess.h
@@ -89,6 +89,7 @@ public:
    */
   WarehouseScanningPulseProcess(
     std::shared_ptr<Scanner> scanner,
+    Scene& scene,
     PulseTaskDropper& dropper,
     PulseWarehouseThreadPool& pool,
     RandomnessGenerator<double>& randGen1,

--- a/src/scanner/beamDeflector/AbstractBeamDeflector.cpp
+++ b/src/scanner/beamDeflector/AbstractBeamDeflector.cpp
@@ -7,8 +7,6 @@
 #include "MathConverter.h"
 #include <logging.hpp>
 
-#define _USE_MATH_DEFINES
-
 // ***  CONSTRUCTION / DESTRUCTION  *** //
 // ************************************ //
 void

--- a/src/scanner/beamDeflector/ConicBeamDeflector.cpp
+++ b/src/scanner/beamDeflector/ConicBeamDeflector.cpp
@@ -1,6 +1,5 @@
 #include "ConicBeamDeflector.h"
 
-#define _USE_MATH_DEFINES
 #include "math.h"
 
 #include "maths/Directions.h"

--- a/src/scanner/beamDeflector/OscillatingMirrorBeamDeflector.cpp
+++ b/src/scanner/beamDeflector/OscillatingMirrorBeamDeflector.cpp
@@ -4,7 +4,6 @@
 #include <sstream>
 using namespace std;
 
-#define _USE_MATH_DEFINES
 #include <logging.hpp>
 #include <math.h>
 

--- a/src/scanner/beamDeflector/PolygonMirrorBeamDeflector.cpp
+++ b/src/scanner/beamDeflector/PolygonMirrorBeamDeflector.cpp
@@ -1,12 +1,11 @@
 #include "PolygonMirrorBeamDeflector.h"
+#include "MathConverter.h"
 #include "maths/Directions.h"
 #include <HeliosException.h>
 #include <iostream>
 #include <logging.hpp>
-#include <sstream>
-#define _USE_MATH_DEFINES
-#include "MathConverter.h"
 #include <math.h>
+#include <sstream>
 
 // ***  CONSTRUCTION / DESTRUCTION  *** //
 // ************************************ //

--- a/src/scanner/detector/AbstractPulseRunnable.cpp
+++ b/src/scanner/detector/AbstractPulseRunnable.cpp
@@ -1,6 +1,5 @@
 #include "AbstractPulseRunnable.h"
 
-#define _USE_MATH_DEFINES
 #include "MathConstants.h"
 #include "math.h"
 #include <maths/EnergyMaths.h>

--- a/src/scanner/detector/AbstractPulseRunnable.cpp
+++ b/src/scanner/detector/AbstractPulseRunnable.cpp
@@ -8,6 +8,7 @@
 #include "AbstractDetector.h"
 #include <filems/facade/FMSFacade.h>
 #include <scanner/PulseRecord.h>
+#include <scene/Scene.h>
 
 #include <glm/glm.hpp>
 
@@ -16,10 +17,11 @@
 // ***  CONSTRUCTION / DESTRUCTION  *** //
 // ************************************ //
 AbstractPulseRunnable::AbstractPulseRunnable(std::shared_ptr<Scanner> scanner,
+                                             Scene& scene,
                                              SimulatedPulse const& pulse)
   : scanner(scanner)
   , pulse(pulse)
-  , scene(*(scanner->platform->scene))
+  , scene(scene)
 {
   // Assign corresponding measurement error function
   AbstractDetector& ad = *scanner->getDetector();

--- a/src/scanner/detector/AbstractPulseRunnable.h
+++ b/src/scanner/detector/AbstractPulseRunnable.h
@@ -6,6 +6,7 @@
 class Measurement;
 #include "LasSpecification.h"
 class Scanner;
+class Scene;
 #include <scanner/SimulatedPulse.h>
 #if DATA_ANALYTICS >= 2
 #include <dataanalytics/HDA_PulseRecorder.h>
@@ -57,6 +58,7 @@ public:
    * @see SimulatedPulse
    */
   AbstractPulseRunnable(std::shared_ptr<Scanner> const scanner,
+                        Scene& scene,
                         SimulatedPulse const& pulse);
 
   // ***  M E T H O D S  *** //

--- a/src/scanner/detector/DynFullWaveformPulseRunnable.h
+++ b/src/scanner/detector/DynFullWaveformPulseRunnable.h
@@ -32,8 +32,9 @@ public:
    */
   DynFullWaveformPulseRunnable(std::shared_ptr<KDGroveRaycaster> raycaster,
                                std::shared_ptr<Scanner> scanner,
+                               Scene& scene,
                                SimulatedPulse const& pulse)
-    : FullWaveformPulseRunnable(scanner, pulse)
+    : FullWaveformPulseRunnable(scanner, scene, pulse)
     , raycaster(raycaster)
   {
   }

--- a/src/scanner/detector/FullWaveformPulseRunnable.cpp
+++ b/src/scanner/detector/FullWaveformPulseRunnable.cpp
@@ -14,6 +14,7 @@
 #include <maths/RayUtils.h>
 #include <scanner/Scanner.h>
 #include <scanner/detector/FullWaveform.h>
+#include <scene/Scene.h>
 
 #if DATA_ANALYTICS >= 2
 #include <dataanalytics/HDA_GlobalVars.h>

--- a/src/scanner/detector/FullWaveformPulseRunnable.cpp
+++ b/src/scanner/detector/FullWaveformPulseRunnable.cpp
@@ -4,7 +4,6 @@
 
 #include "logging.hpp"
 
-#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "maths/Rotation.h"

--- a/src/scanner/detector/FullWaveformPulseRunnable.h
+++ b/src/scanner/detector/FullWaveformPulseRunnable.h
@@ -43,8 +43,9 @@ public:
    * @see SimulatedPulse
    */
   FullWaveformPulseRunnable(std::shared_ptr<Scanner> scanner,
+                            Scene& scene,
                             SimulatedPulse const& pulse)
-    : AbstractPulseRunnable(scanner, pulse)
+    : AbstractPulseRunnable(scanner, scene, pulse)
   {
   }
 

--- a/src/scanner/detector/PulseTaskFactory.cpp
+++ b/src/scanner/detector/PulseTaskFactory.cpp
@@ -19,7 +19,8 @@ PulseTaskFactory::buildFullWaveformPulseRunnable(
   ScanningPulseProcess const& spp,
   SimulatedPulse const& sp) const
 {
-  return std::make_shared<FullWaveformPulseRunnable>(spp.getScanner(), sp);
+  return std::make_shared<FullWaveformPulseRunnable>(
+    spp.getScanner(), scene, sp);
 }
 
 std::shared_ptr<PulseTask>
@@ -28,7 +29,7 @@ PulseTaskFactory::buildDynFullWaveformPulseRunnable(
   SimulatedPulse const& sp) const
 {
   return std::make_shared<DynFullWaveformPulseRunnable>(
-    scene.getRaycaster()->makeTemporalClone(), spp.getScanner(), sp);
+    scene.getRaycaster()->makeTemporalClone(), spp.getScanner(), scene, sp);
 }
 
 void

--- a/src/scene/primitives/Triangle.cpp
+++ b/src/scene/primitives/Triangle.cpp
@@ -1,6 +1,5 @@
 #include "Triangle.h"
 
-#define _USE_MATH_DEFINES
 #include "math.h"
 #include <MathConstants.h>
 

--- a/src/sim/comps/SimulationPlayer.cpp
+++ b/src/sim/comps/SimulationPlayer.cpp
@@ -16,7 +16,7 @@ using namespace std::chrono;
 // ************************************ //
 SimulationPlayer::SimulationPlayer(Simulation& sim)
   : sim(sim)
-  , scene(*sim.getScanner()->platform->scene)
+  , scene(sim.getScene())
   , plays(0)
   , platformStart(sim.getScanner()->platform->clone())
 {
@@ -75,7 +75,7 @@ SimulationPlayer::endPlay()
     restartScanner(*sim.getScanner());
     // Restart scene
     logging::DEBUG("Restarting scene for next simulation play ...");
-    restartScene(*sim.getScanner()->platform->scene, keepCRS);
+    restartScene(sim.getScene(), keepCRS);
     // Restart simulation
     logging::DEBUG("Restarting context for next simulation play ...");
     restartSimulation(sim);

--- a/src/sim/comps/SimulationReporter.cpp
+++ b/src/sim/comps/SimulationReporter.cpp
@@ -61,7 +61,7 @@ std::string
 SimulationReporter::reportDynMovingObjects() const
 {
   // Check that there are moving objects
-  Scene& scene = *(sim.mScanner->platform->scene);
+  Scene& scene = sim.getScene();
   if (!scene.hasMovingObjects())
     return "";
 

--- a/src/sim/comps/Survey.cpp
+++ b/src/sim/comps/Survey.cpp
@@ -3,11 +3,29 @@
 
 #include "Survey.h"
 #include <AbstractDetector.h>
+#include <HeliosException.h>
 #include <Simulation.h>
 #include <SurveyPlayback.h>
 #include <platform/InterpolatedMovingPlatformEgg.h>
 #include <scene/StaticScene.h>
 #include <scene/dynamic/DynScene.h>
+
+namespace {
+std::shared_ptr<Scene>
+cloneScene(std::shared_ptr<Scene> const& scene)
+{
+  if (scene == nullptr)
+    return nullptr;
+
+  if (auto dynScene = std::dynamic_pointer_cast<DynScene>(scene)) {
+    return std::make_shared<DynScene>(*dynScene);
+  }
+  if (auto staticScene = std::dynamic_pointer_cast<StaticScene>(scene)) {
+    return std::make_shared<StaticScene>(*staticScene);
+  }
+  return std::make_shared<Scene>(*scene);
+}
+}
 
 // ***  CONSTRUCTION / DESTRUCTION  *** //
 // ************************************ //
@@ -25,24 +43,13 @@ Survey::Survey(Survey& survey, bool const deepCopy)
     this->scanner->getDetector(i)->scanner = this->scanner;
   }
 
+  // Copy scene
+  this->scene = deepCopy ? cloneScene(survey.getScene()) : survey.getScene();
+
   // Copy legs
   this->legs = std::vector<std::shared_ptr<Leg>>(0);
   for (size_t i = 0; i < survey.legs.size(); i++) {
     this->legs.push_back(std::make_shared<Leg>(*survey.legs[i]));
-  }
-
-  // Make deep copy effective
-  if (deepCopy && this->scanner->platform->scene != nullptr) {
-    auto scene = this->scanner->platform->scene;
-    if (auto dynScene = std::dynamic_pointer_cast<DynScene>(scene)) {
-      this->scanner->platform->scene = std::make_shared<DynScene>(*dynScene);
-    } else if (auto staticScene =
-                 std::dynamic_pointer_cast<StaticScene>(scene)) {
-      this->scanner->platform->scene =
-        std::make_shared<StaticScene>(*staticScene);
-    } else {
-      this->scanner->platform->scene = std::make_shared<Scene>(*scene);
-    }
   }
 }
 
@@ -60,6 +67,27 @@ void
 Survey::removeLeg(int legIndex)
 {
   legs.erase(legs.begin() + legIndex);
+}
+
+std::shared_ptr<Scene>
+Survey::getScene() const
+{
+  return scene;
+}
+
+Scene&
+Survey::requireScene() const
+{
+  if (scene == nullptr) {
+    throw HeliosException("Survey has no scene assigned");
+  }
+  return *scene;
+}
+
+void
+Survey::setScene(std::shared_ptr<Scene> scene)
+{
+  this->scene = scene;
 }
 
 void

--- a/src/sim/comps/Survey.h
+++ b/src/sim/comps/Survey.h
@@ -4,6 +4,7 @@
 #include <Asset.h>
 #include <Leg.h>
 #include <Scanner.h>
+#include <Scene.h>
 
 class SurveyPlayback;
 
@@ -28,6 +29,11 @@ public:
    * @see Scanner
    */
   std::shared_ptr<Scanner> scanner = nullptr;
+  /**
+   * @brief Scene used by the survey
+   * @see Scene
+   */
+  std::shared_ptr<Scene> scene = nullptr;
   /**
    * @brief Simulation speed factor for the survey
    */
@@ -73,6 +79,25 @@ public:
    * @see Leg
    */
   void removeLeg(int legIndex);
+  /**
+   * @brief Obtain the scene used by the survey
+   * @return Survey scene
+   * @see Survey::scene
+   */
+  std::shared_ptr<Scene> getScene() const;
+  /**
+   * @brief Obtain the scene used by the survey by reference
+   * @return Survey scene by reference
+   * @throws HeliosException if no scene has been assigned
+   * @see Survey::scene
+   */
+  Scene& requireScene() const;
+  /**
+   * @brief Set the scene used by the survey
+   * @param scene New survey scene
+   * @see Survey::scene
+   */
+  void setScene(std::shared_ptr<Scene> scene);
 
   /**
    * @brief Compute survey length (distance passing through all legs)

--- a/src/sim/core/Simulation.cpp
+++ b/src/sim/core/Simulation.cpp
@@ -5,9 +5,11 @@
 using namespace std::chrono;
 
 #include "AbstractDetector.h"
+#include <HeliosException.h>
 #include <platform/InterpolatedMovingPlatform.h>
 #include <platform/InterpolatedMovingPlatformEgg.h>
 #include <scanner/BuddingScanningPulseProcess.h>
+#include <scene/Scene.h>
 #include <scene/dynamic/DynScene.h>
 #ifdef DATA_ANALYTICS
 #include <dataanalytics/HDA_SimStepRecorder.h>
@@ -70,7 +72,7 @@ Simulation::prepareSimulation(int simFrequency_hz)
   // Prepare scanner
   this->mScanner->prepareSimulation(legacyEnergyModel);
   this->mScanner->buildScanningPulseProcess(
-    parallelizationStrategy, taskDropper, threadPool);
+    parallelizationStrategy, taskDropper, threadPool, getScene());
 
   // Prepare simulation
   setSimFrequency(this->mScanner->getPulseFreq_Hz());
@@ -78,7 +80,7 @@ Simulation::prepareSimulation(int simFrequency_hz)
   stepGpsTime_ns = 1000000000. * stepLoop.getPeriod();
 
   // Prepare scene (mostly for dynamic scenes)
-  mScanner->platform->scene->prepareSimulation(simFrequency_hz);
+  getScene().prepareSimulation(simFrequency_hz);
 }
 
 void
@@ -93,8 +95,8 @@ Simulation::doSimStep()
 
   // Ordered execution of simulation components
   mScanner->platform->doSimStep(mScanner->getPulseFreq_Hz());
-  mScanner->doSimStep(mCurrentLegIndex, currentGpsTime_ns);
-  mScanner->platform->scene->doSimStep();
+  mScanner->doSimStep(mCurrentLegIndex, currentGpsTime_ns, getScene());
+  getScene().doSimStep();
   currentGpsTime_ns += stepGpsTime_ns;
   if (currentGpsTime_ns > 604800000000000.)
     currentGpsTime_ns -= 604800000000000.;
@@ -649,4 +651,19 @@ Simulation::setScanner(std::shared_ptr<Scanner> scanner)
   logging::INFO("Simulation: Scanner changed!");
 
   this->mScanner = std::shared_ptr<Scanner>(scanner);
+}
+
+void
+Simulation::setScene(Scene& scene)
+{
+  this->mScene = &scene;
+}
+
+Scene&
+Simulation::getScene() const
+{
+  if (mScene == nullptr) {
+    throw HeliosException("Simulation has no scene assigned");
+  }
+  return *mScene;
 }

--- a/src/sim/core/Simulation.h
+++ b/src/sim/core/Simulation.h
@@ -19,6 +19,8 @@
 #include <exception>
 #include <vector>
 
+class Scene;
+
 /**
  * @brief Class representing a simulation
  */
@@ -61,6 +63,11 @@ protected:
    * @see Scanner
    */
   std::shared_ptr<Scanner> mScanner = nullptr;
+  /**
+   * @brief Scene used by the simulation
+   * @see Scene
+   */
+  Scene* mScene = nullptr;
 
   /**
    * @brief The handler for simulation steps, it also contains the discrete
@@ -347,11 +354,23 @@ public:
    */
   void setScanner(std::shared_ptr<Scanner> scanner);
   /**
+   * @brief Set scene for the simulation
+   * @param scene New scene for the simulation
+   * @see Simulation::mScene
+   */
+  void setScene(Scene& scene);
+  /**
    * @brief Obtain simulation scanner
    * @return Simulation scanner
    * @see Simulation::mScanner
    */
   inline std::shared_ptr<Scanner> getScanner() { return this->mScanner; }
+  /**
+   * @brief Obtain simulation scene
+   * @return Simulation scene
+   * @see Simulation::mScene
+   */
+  Scene& getScene() const;
 
   /**
    * @brief Check if simulation is paused (true) or not (false)

--- a/src/sim/core/SurveyPlayback.cpp
+++ b/src/sim/core/SurveyPlayback.cpp
@@ -47,6 +47,7 @@ SurveyPlayback::SurveyPlayback(
   this->exitAtEnd = true;
   this->exportToFile = exportToFile;
   this->setScanner(mSurvey->scanner);
+  this->setScene(mSurvey->requireScene());
 
   // Disable exports if requested
   if (!this->exportToFile) {
@@ -63,8 +64,7 @@ SurveyPlayback::SurveyPlayback(
 
     // Set leg position to the center of the scene:
     shared_ptr<PlatformSettings> ps = make_shared<PlatformSettings>();
-    ps->setPosition(
-      mSurvey->scanner->platform->scene->getAABB()->getCentroid());
+    ps->setPosition(mSurvey->requireScene().getAABB()->getCentroid());
     leg->mPlatformSettings = ps;
 
     // Add leg to survey:
@@ -422,7 +422,6 @@ SurveyPlayback::shutdown()
   Simulation::shutdown();
   if (!disableShutdown) {
     mSurvey->scanner->getDetector()->shutdown();
-    mSurvey->scanner->platform->scene->shutdown();
   }
 }
 

--- a/src/sim/tools/DiscreteTime.h
+++ b/src/sim/tools/DiscreteTime.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <cstdlib>
-#define _USE_MATH_DEFINES
 #include <cmath>
+#include <cstdlib>
 
 /**
  * @author Alberto M. Esmoris Pena

--- a/src/test/FunctionalPlatformTest.cpp
+++ b/src/test/FunctionalPlatformTest.cpp
@@ -3,6 +3,8 @@
 #undef INFO
 #include "logging.hpp"
 #include <platform/InterpolatedMovingPlatform.h>
+#include <string>
+#include <vector>
 
 TEST_CASE("Functional platform test ")
 {
@@ -23,7 +25,7 @@ TEST_CASE("Functional platform test ")
                       "1.2   6  -1   1"),
     0,
     "t",
-    vector<string>({ "t", "x", "y", "z" }));
+    std::vector<std::string>({ "t", "x", "y", "z" }));
   fluxionum::DiffDesignMatrix<double, double> ddm = tdm.toDiffDesignMatrix();
   InterpolatedMovingPlatform imp(
     stepLoop,

--- a/src/test/SurveyCopyTest.cpp
+++ b/src/test/SurveyCopyTest.cpp
@@ -49,7 +49,7 @@ TEST_CASE("Survey Copy Test")
   survey->legs[0]->mPlatformSettings->onGround = false;
 
   std::shared_ptr<Scene> baseScene = std::make_shared<Scene>();
-  survey->scanner->platform->scene = baseScene;
+  survey->scene = baseScene;
 
   baseScene->primitives.push_back(new Triangle(Vertex(), Vertex(), Vertex()));
   baseScene->primitives[0]->part = std::make_shared<ScenePart>();
@@ -88,7 +88,7 @@ TEST_CASE("Survey Copy Test")
   copy->scanner->getFWFSettings().minEchoWidth += 0.001;
   copy->legs[0]->mPlatformSettings->onGround = true;
 
-  std::shared_ptr<Scene> copyScene = copy->scanner->platform->scene;
+  std::shared_ptr<Scene> copyScene = copy->scene;
   copyScene->primitives[0]->getVertices()[0].pos.x += 0.1;
   copyScene->primitives[0]->part->onRayIntersectionArgument += 0.034;
   copyScene->primitives[1]->material->ks[1] += 0.1;

--- a/tests/python/test_survey.py
+++ b/tests/python/test_survey.py
@@ -8,9 +8,9 @@ from helios.platforms import (
     simple_linearpath,
     StaticPlatformSettings,
 )
-from helios.scanner import Scanner, riegl_lms_q560, riegl_vz_400
+from helios.scanner import Scanner, riegl_lms_q560, riegl_vz_1000, riegl_vz_400
 from helios.scene import StaticScene, ScenePart
-from helios.settings import ExecutionSettings
+from helios.settings import ExecutionSettings, OutputFormat, ProgressBarStrategy
 from helios.survey import *
 from helios.utils import set_rng_seed
 from helios import HeliosException
@@ -80,6 +80,61 @@ def test_survey_clone_run_matches_point_cloud(survey):
     assert cloned_survey.scene is not survey.scene
     np.testing.assert_array_equal(points, cloned_points)
     np.testing.assert_array_equal(trajectory, cloned_trajectory)
+
+
+def test_surveys_sharing_scene_match_deep_copied_scenes():
+    execution_settings = ExecutionSettings(
+        num_threads=1,
+        kdt_num_threads=1,
+        kdt_geom_num_threads=1,
+        progressbar=ProgressBarStrategy.NONE,
+    )
+    scanner_settings = ScannerSettings(
+        pulse_frequency=2000,
+        scan_frequency=20,
+        scan_angle="10 deg",
+        head_rotation="20 deg/s",
+        rotation_start_angle="0 deg",
+        rotation_stop_angle="1 deg",
+    )
+    platform_settings = StaticPlatformSettings(x=0, y=0, z=0)
+    shared_scene = StaticScene(
+        scene_parts=[ScenePart.from_obj("data/sceneparts/basic/box/box100.obj")]
+    )
+
+    def make_survey(scanner_factory, scene):
+        survey = Survey(scanner=scanner_factory(), platform=tripod(), scene=scene)
+        survey.add_leg(
+            scanner_settings=copy.deepcopy(scanner_settings),
+            platform_settings=copy.deepcopy(platform_settings),
+        )
+        return survey
+
+    survey_pairs = [
+        (
+            make_survey(riegl_vz_400, shared_scene),
+            make_survey(riegl_vz_400, copy.deepcopy(shared_scene)),
+        ),
+        (
+            make_survey(riegl_vz_1000, shared_scene),
+            make_survey(riegl_vz_1000, copy.deepcopy(shared_scene)),
+        ),
+    ]
+
+    assert survey_pairs[0][0].scene is shared_scene
+    assert survey_pairs[1][0].scene is shared_scene
+
+    for shared_survey, copied_scene_survey in survey_pairs:
+        shared_points, shared_trajectory = shared_survey.run(
+            format=OutputFormat.NPY, execution_settings=execution_settings
+        )
+        copied_points, copied_trajectory = copied_scene_survey.run(
+            format=OutputFormat.NPY, execution_settings=execution_settings
+        )
+
+        assert 0 < shared_points.shape[0] <= 10
+        np.testing.assert_array_equal(shared_points, copied_points)
+        np.testing.assert_array_equal(shared_trajectory, copied_trajectory)
 
 
 def test_add_leg_parameters():


### PR DESCRIPTION
This is achieved by disentangling the internal ownership of pointers.
The scene is now directly owned by the survey and passed to the scanner/platform
upon running. Before, scanner/platform hold a copy of the shared pointer. Therefore
surveys that shared a scene would implicitly couple.

Assisted by codex/GPT5.5