### PR TITLE
Added snapToSurface feature for multi-return 

### DIFF
--- a/data/scenes/toyblocks/tiny_toyblocks_scene.xml
+++ b/data/scenes/toyblocks/tiny_toyblocks_scene.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document>
+    <scene id="tiny_toyblocks_scene" name="ToyblocksScene">
+        <part>
+            <filter type="objloader">
+                <param type="string" key="filepath" value="data/sceneparts/basic/groundplane/groundplane.obj" />
+            </filter>
+            <filter type="scale">
+                <param type="double" key="scale" value="2.1" />
+            </filter>
+			<filter type="translate">
+				<param type="vec3" key="offset" value="0.6;0;0" />
+			</filter>
+        </part>
+        <part>
+            <filter type="objloader">
+                <param type="string" key="filepath" value="data/sceneparts/toyblocks/cube.obj" />
+            </filter>
+			<filter type="scale">
+                <param type="double" key="scale" value="0.03" />
+            </filter>
+        </part>
+		<part>
+            <filter type="objloader">
+                <param type="string" key="filepath" value="data/sceneparts/toyblocks/cube.obj" />
+            </filter>
+			<filter type="rotate">
+				<param key="rotation" type="rotation">
+					<rot angle_deg="45" axis="z"/>
+				</param>
+			</filter>
+			<filter type="scale">
+                <param type="double" key="scale" value="0.015" />
+            </filter>
+			<filter type="translate">
+				<param type="integer" key="onGround" value="-1" />
+                <param type="vec3" key="offset" value="-1.35;0.3;0.3" />
+			</filter>
+        </part>
+        <part>
+            <filter type="objloader">
+                <param type="string" key="filepath" value="data/sceneparts/toyblocks/sphere.obj" />
+            </filter>
+			<filter type="scale">
+                <param type="double" key="scale" value="0.015" />
+            </filter>
+        </part>
+         <part>
+            <filter type="objloader">
+                <param type="string" key="filepath" value="data/sceneparts/toyblocks/cylinder.obj" />
+            </filter>
+			<filter type="scale">
+                <param type="double" key="scale" value="0.03" />
+            </filter>
+        </part>
+    </scene>
+</document>

--- a/data/surveys/toyblocks/tiny_toyblocks_uls_snapToSurface.xml
+++ b/data/surveys/toyblocks/tiny_toyblocks_uls_snapToSurface.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<document>
+    <survey name="toyblocks_uls_snapToSurface" platform="data/platforms.xml#sr22" scanner="data/scanners_als.xml#dji-zenmuse-l2-non-repetitive" scene="data/scenes/toyblocks/tiny_toyblocks_scene.xml#tiny_toyblocks_scene">
+	<!-- platform: sr22, deflector: risley -->
+	<!-- sensor: dji-zenmuse-l2-non-repetitive -->
+
+	<!-- Can change platform to "copter-linearpath" and sensor to "riegl_vux-1uav22" to test a rotating deflector.
+		The effect is still present, but less pronounced. -->
+
+	<!-- scene: a scaled down version of the toyblocks scene. 
+		This amplifies the percentage effect of the snapToSurface option and places the cylinder at 60cm diameter, 
+		equivalent to a large tree. The effect lessens as object size increases with a static survey/sensor configuration.-->
+	
+	<FWFSettings snapToSurface="true" beamSampleQuality="5" binSize_ns="0.25"/>
+		<!-- snapToSurface ON: same 4 strips -->
+		<!-- To test the default output, change snapToSurface to false -->
+		<leg stripId="0">
+			<platformSettings x="-30.0" y="-30.0" z="80.000" onGround="false" movePerSec_m="1" smoothTurn="true" slowdownEnabled="false"/>
+			<scannerSettings active="true" pulseFreq_hz="40000" scanAngle_deg="50" trajectoryTimeInterval_s="0.01">
+				<FWFSettings beamSampleQuality="5" snapToSurface="true"/>
+			</scannerSettings>
+		</leg>
+		<leg stripId="0">
+			<platformSettings x="30.0" y="-30.0" z="80.000" onGround="false" movePerSec_m="1" smoothTurn="true" slowdownEnabled="false"/>
+			<scannerSettings active="false" pulseFreq_hz="40000" scanAngle_deg="50" trajectoryTimeInterval_s="0.01">
+				<FWFSettings beamSampleQuality="5" snapToSurface="true"/>
+			</scannerSettings>
+		</leg>
+
+		<leg stripId="1">
+			<platformSettings x="30.0" y="30.0" z="80.000" onGround="false" movePerSec_m="1" smoothTurn="true" slowdownEnabled="false"/>
+			<scannerSettings active="true" pulseFreq_hz="40000" scanAngle_deg="50" trajectoryTimeInterval_s="0.01">
+				<FWFSettings beamSampleQuality="5" snapToSurface="true"/>
+			</scannerSettings>
+		</leg>
+		<leg stripId="1">
+			<platformSettings x="-30.0" y="30.0" z="80.000" onGround="false" movePerSec_m="1" smoothTurn="true" slowdownEnabled="false"/>
+			<scannerSettings active="false" pulseFreq_hz="40000" scanAngle_deg="50" trajectoryTimeInterval_s="0.01">
+				<FWFSettings beamSampleQuality="5" snapToSurface="true"/>
+			</scannerSettings>
+		</leg>
+
+		<leg stripId="2">
+			<platformSettings x="-30.0" y="-30.0" z="80.000" onGround="false" movePerSec_m="1" smoothTurn="true" slowdownEnabled="false"/>
+			<scannerSettings active="true" pulseFreq_hz="40000" scanAngle_deg="50" trajectoryTimeInterval_s="0.01">
+				<FWFSettings beamSampleQuality="5" snapToSurface="true"/>
+			</scannerSettings>
+		</leg>
+		<leg stripId="2">
+			<platformSettings x="-30.0" y="30.0" z="80.000" onGround="false" movePerSec_m="1" smoothTurn="true" slowdownEnabled="false"/>
+			<scannerSettings active="false" pulseFreq_hz="40000" scanAngle_deg="50" trajectoryTimeInterval_s="0.01">
+				<FWFSettings beamSampleQuality="5" snapToSurface="true"/>
+			</scannerSettings>
+		</leg>
+
+		<leg stripId="3">
+			<platformSettings x="30.0" y="30.0" z="80.000" onGround="false" movePerSec_m="1" smoothTurn="true" slowdownEnabled="false"/>
+			<scannerSettings active="true" pulseFreq_hz="40000" scanAngle_deg="50" trajectoryTimeInterval_s="0.01">
+				<FWFSettings beamSampleQuality="5" snapToSurface="true"/>
+			</scannerSettings>
+		</leg>
+		<leg stripId="3">
+			<platformSettings x="30.0" y="-30.0" z="80.000" onGround="false" movePerSec_m="1" smoothTurn="true" slowdownEnabled="false"/>
+			<scannerSettings active="false" pulseFreq_hz="40000" scanAngle_deg="50" trajectoryTimeInterval_s="0.01">
+				<FWFSettings beamSampleQuality="5" snapToSurface="true"/>
+			</scannerSettings>
+		</leg>
+	</survey>
+</document>

--- a/python/pyhelios/util/xsd/scanner.xsd
+++ b/python/pyhelios/util/xsd/scanner.xsd
@@ -35,6 +35,7 @@
                                             <xs:attribute type="xs:float" name="binSize_ns"/>
                                             <xs:attribute type="xs:float" name="maxFullwaveRange_ns"/>
                                             <xs:attribute type="xs:float" name="winSize_ns"/>
+                                            <xs:attribute type="xs:boolean" name="snapToSurface"/>
                                         </xs:extension>
                                     </xs:simpleContent>
                                 </xs:complexType>
@@ -84,6 +85,7 @@
                                                                     <xs:attribute type="xs:float" name="binSize_ns"/>
                                                                     <xs:attribute type="xs:float" name="maxFullwaveRange_ns"/>
                                                                     <xs:attribute type="xs:float" name="winSize_ns"/>
+                                                                    <xs:attribute type="xs:boolean" name="snapToSurface"/>
                                                                 </xs:extension>
                                                             </xs:simpleContent>
                                                         </xs:complexType>

--- a/python/pyhelios/util/xsd/survey.xsd
+++ b/python/pyhelios/util/xsd/survey.xsd
@@ -89,6 +89,7 @@
                                             <xs:attribute type="xs:float" name="binSize_ns" use="optional"/>
                                             <xs:attribute type="xs:float" name="maxFullwaveRange_ns" use="optional"/>
                                             <xs:attribute type="xs:float" name="winSize_ns" use="optional"/>
+                                            <xs:attribute type="xs:boolean" name="snapToSurface" use="optional"/>
                                         </xs:extension>
                                     </xs:simpleContent>
                                 </xs:complexType>

--- a/src/assetloading/XmlAssetsLoader.cpp
+++ b/src/assetloading/XmlAssetsLoader.cpp
@@ -1278,9 +1278,6 @@ XmlAssetsLoader::createFWFSettingsFromXml(tinyxml2::XMLElement* node,
       node, "apertureDiameter_m", settings->apertureDiameter);
     settings->snapToSurface = XmlUtils::getAttributeCast<bool>(
       node, "snapToSurface", settings->snapToSurface);
-    // Backward compatibility for previous naming.
-    settings->snapToSurface = XmlUtils::getAttributeCast<bool>(
-      node, "useSubrayDiscretePoint", settings->snapToSurface);
   }
 
   return settings;

--- a/src/assetloading/XmlAssetsLoader.cpp
+++ b/src/assetloading/XmlAssetsLoader.cpp
@@ -1276,6 +1276,11 @@ XmlAssetsLoader::createFWFSettingsFromXml(tinyxml2::XMLElement* node,
       node, "maxFullwaveRange_ns", settings->maxFullwaveRange_ns);
     settings->apertureDiameter = XmlUtils::getAttributeCast<double>(
       node, "apertureDiameter_m", settings->apertureDiameter);
+    settings->snapToSurface = XmlUtils::getAttributeCast<bool>(
+      node, "snapToSurface", settings->snapToSurface);
+    // Backward compatibility for previous naming.
+    settings->snapToSurface = XmlUtils::getAttributeCast<bool>(
+      node, "useSubrayDiscretePoint", settings->snapToSurface);
   }
 
   return settings;

--- a/src/assetloading/XmlSurveyLoader.cpp
+++ b/src/assetloading/XmlSurveyLoader.cpp
@@ -289,14 +289,10 @@ XmlSurveyLoader::loadSurveyCore(tinyxml2::XMLElement* surveyNode,
   // Load fullwave form
   tinyxml2::XMLElement* scannerFWFSettingsNode =
     surveyNode->FirstChildElement("FWFSettings");
-  size_t const numDevices = survey->scanner->getNumDevices();
-  for (size_t devIdx = 0; devIdx < numDevices; ++devIdx) {
-    survey->scanner->applySettingsFWF(
-      *createFWFSettingsFromXml(scannerFWFSettingsNode,
-                                std::make_shared<FWFSettings>(FWFSettings(
-                                  survey->scanner->getFWFSettings(devIdx)))),
-      devIdx);
-  }
+  survey->scanner->applySettingsFWF(
+    *createFWFSettingsFromXml(scannerFWFSettingsNode,
+                              std::make_shared<FWFSettings>(FWFSettings(
+                                survey->scanner->getFWFSettings()))));
   // Read number of runs
   survey->numRuns = XmlUtils::getAttributeCast<int>(surveyNode, "numRuns", 1);
   // Load initial simulation speed factor

--- a/src/assetloading/XmlSurveyLoader.cpp
+++ b/src/assetloading/XmlSurveyLoader.cpp
@@ -289,10 +289,15 @@ XmlSurveyLoader::loadSurveyCore(tinyxml2::XMLElement* surveyNode,
   // Load fullwave form
   tinyxml2::XMLElement* scannerFWFSettingsNode =
     surveyNode->FirstChildElement("FWFSettings");
-  survey->scanner->applySettingsFWF(
-    *createFWFSettingsFromXml(scannerFWFSettingsNode,
-                              std::make_shared<FWFSettings>(FWFSettings(
-                                survey->scanner->getFWFSettings()))));
+  size_t const numDevices = survey->scanner->getNumDevices();
+  for (size_t devIdx = 0; devIdx < numDevices; ++devIdx) {
+    survey->scanner->applySettingsFWF(
+      *createFWFSettingsFromXml(
+        scannerFWFSettingsNode,
+        std::make_shared<FWFSettings>(
+          FWFSettings(survey->scanner->getFWFSettings(devIdx)))),
+      devIdx);
+  }
   // Read number of runs
   survey->numRuns = XmlUtils::getAttributeCast<int>(surveyNode, "numRuns", 1);
   // Load initial simulation speed factor

--- a/src/assetloading/XmlSurveyLoader.cpp
+++ b/src/assetloading/XmlSurveyLoader.cpp
@@ -292,10 +292,9 @@ XmlSurveyLoader::loadSurveyCore(tinyxml2::XMLElement* surveyNode,
   size_t const numDevices = survey->scanner->getNumDevices();
   for (size_t devIdx = 0; devIdx < numDevices; ++devIdx) {
     survey->scanner->applySettingsFWF(
-      *createFWFSettingsFromXml(
-        scannerFWFSettingsNode,
-        std::make_shared<FWFSettings>(
-          FWFSettings(survey->scanner->getFWFSettings(devIdx)))),
+      *createFWFSettingsFromXml(scannerFWFSettingsNode,
+                                std::make_shared<FWFSettings>(FWFSettings(
+                                  survey->scanner->getFWFSettings(devIdx)))),
       devIdx);
   }
   // Read number of runs

--- a/src/main/LidarSim.cpp
+++ b/src/main/LidarSim.cpp
@@ -16,17 +16,35 @@ namespace fms = helios::filems;
 namespace helios {
 namespace main {
 
-void LidarSim::init(std::string surveyPath, std::vector<std::string> assetsPath,
-                    std::string outputPath, bool writeWaveform, bool writePulse,
-                    bool calcEchowidth, int parallelizationStrategy,
-                    size_t njobs, int chunkSize, int warehouseFactor,
-                    bool fullWaveNoise, bool splitByChannel,
-                    bool platformNoiseDisabled, bool legNoiseDisabled,
-                    bool rebuildScene, bool writeScene, bool lasOutput,
-                    bool las10, bool zipOutput, bool fixedIncidenceAngle,
-                    std::string gpsStartTime, double lasScale, int kdtType,
-                    size_t kdtJobs, size_t kdtGeomJobs, size_t sahLossNodes,
-                    bool const legacyEnergyModel) {
+void
+LidarSim::init(std::string surveyPath,
+               std::vector<std::string> assetsPath,
+               std::string outputPath,
+               bool writeWaveform,
+               bool writePulse,
+               bool calcEchowidth,
+               int parallelizationStrategy,
+               size_t njobs,
+               int chunkSize,
+               int warehouseFactor,
+               bool fullWaveNoise,
+               bool splitByChannel,
+               bool platformNoiseDisabled,
+               bool legNoiseDisabled,
+               bool rebuildScene,
+               bool writeScene,
+               bool lasOutput,
+               bool las10,
+               bool zipOutput,
+               bool fixedIncidenceAngle,
+               std::string gpsStartTime,
+               double lasScale,
+               int kdtType,
+               size_t kdtJobs,
+               size_t kdtGeomJobs,
+               size_t sahLossNodes,
+               bool const legacyEnergyModel)
+{
   // Info about execution arguments
   std::stringstream ss;
   ss << "surveyPath: \"" << surveyPath << "\"\n"
@@ -61,13 +79,13 @@ void LidarSim::init(std::string surveyPath, std::vector<std::string> assetsPath,
 
   // Load survey description from XML file:
   std::shared_ptr<XmlSurveyLoader> xmlreader =
-      std::make_shared<XmlSurveyLoader>(surveyPath, assetsPath, writeScene);
+    std::make_shared<XmlSurveyLoader>(surveyPath, assetsPath, writeScene);
   xmlreader->sceneLoader.kdtFactoryType = kdtType;
   xmlreader->sceneLoader.kdtNumJobs = kdtJobs;
   xmlreader->sceneLoader.kdtGeomJobs = kdtGeomJobs;
   xmlreader->sceneLoader.kdtSAHLossNodes = sahLossNodes;
   std::shared_ptr<Survey> survey =
-      xmlreader->load(legNoiseDisabled, rebuildScene);
+    xmlreader->load(legNoiseDisabled, rebuildScene);
   if (survey == nullptr) {
     logging::ERR("Failed to load survey!");
     exit(-1);
@@ -83,8 +101,7 @@ void LidarSim::init(std::string surveyPath, std::vector<std::string> assetsPath,
 
   // Build main facade for File Management System, associated to the survey
   std::shared_ptr<fms::FMSFacade> fms = fms::FMSFacadeFactory().buildFacade(
-      outputPath, lasScale, lasOutput, las10, zipOutput, splitByChannel,
-      *survey);
+    outputPath, lasScale, lasOutput, las10, zipOutput, splitByChannel, *survey);
 
   // Build thread pool for parallel computation
   /*
@@ -94,22 +111,29 @@ void LidarSim::init(std::string surveyPath, std::vector<std::string> assetsPath,
   unsigned numSysThreads = std::thread::hardware_concurrency();
   std::size_t const poolSize = (njobs == 0) ? numSysThreads - 1 : njobs - 1;
   PulseThreadPoolFactory ptpf(
-      parallelizationStrategy, poolSize,
-      survey->scanner->getDetector()->cfg_device_accuracy_m, chunkSize,
-      warehouseFactor);
+    parallelizationStrategy,
+    poolSize,
+    survey->scanner->getDetector()->cfg_device_accuracy_m,
+    chunkSize,
+    warehouseFactor);
   std::shared_ptr<PulseThreadPoolInterface> pulseThreadPool =
-      ptpf.makePulseThreadPool();
+    ptpf.makePulseThreadPool();
 
   // Build the survey playback simulation itself
-  std::shared_ptr<SurveyPlayback> playback = std::make_shared<SurveyPlayback>(
-      survey, fms, parallelizationStrategy, pulseThreadPool,
-      std::abs(chunkSize), gpsStartTime, legacyEnergyModel);
+  std::shared_ptr<SurveyPlayback> playback =
+    std::make_shared<SurveyPlayback>(survey,
+                                     fms,
+                                     parallelizationStrategy,
+                                     pulseThreadPool,
+                                     std::abs(chunkSize),
+                                     gpsStartTime,
+                                     legacyEnergyModel);
 
   // Print a startup notice if snap-to-surface is enabled on any device.
   std::size_t snapToSurfaceEnabledCount = 0;
   std::size_t const numDevices = survey->scanner->getNumDevices();
   for (std::size_t devIdx = 0; devIdx < numDevices; ++devIdx) {
-    FWFSettings const &fwfSettings = survey->scanner->getFWFSettings(devIdx);
+    FWFSettings const& fwfSettings = survey->scanner->getFWFSettings(devIdx);
     if (fwfSettings.snapToSurface && fwfSettings.beamSampleQuality > 1) {
       ++snapToSurfaceEnabledCount;
     }
@@ -141,7 +165,9 @@ void LidarSim::init(std::string surveyPath, std::vector<std::string> assetsPath,
   release(playback);
 }
 
-void LidarSim::release(std::shared_ptr<SurveyPlayback> sp) {
+void
+LidarSim::release(std::shared_ptr<SurveyPlayback> sp)
+{
   // Release scanner
   std::shared_ptr<Scanner> sc = sp->mSurvey->scanner;
   sc->randGen1 = nullptr;

--- a/src/main/LidarSim.cpp
+++ b/src/main/LidarSim.cpp
@@ -16,35 +16,17 @@ namespace fms = helios::filems;
 namespace helios {
 namespace main {
 
-void
-LidarSim::init(std::string surveyPath,
-               std::vector<std::string> assetsPath,
-               std::string outputPath,
-               bool writeWaveform,
-               bool writePulse,
-               bool calcEchowidth,
-               int parallelizationStrategy,
-               size_t njobs,
-               int chunkSize,
-               int warehouseFactor,
-               bool fullWaveNoise,
-               bool splitByChannel,
-               bool platformNoiseDisabled,
-               bool legNoiseDisabled,
-               bool rebuildScene,
-               bool writeScene,
-               bool lasOutput,
-               bool las10,
-               bool zipOutput,
-               bool fixedIncidenceAngle,
-               std::string gpsStartTime,
-               double lasScale,
-               int kdtType,
-               size_t kdtJobs,
-               size_t kdtGeomJobs,
-               size_t sahLossNodes,
-               bool const legacyEnergyModel)
-{
+void LidarSim::init(std::string surveyPath, std::vector<std::string> assetsPath,
+                    std::string outputPath, bool writeWaveform, bool writePulse,
+                    bool calcEchowidth, int parallelizationStrategy,
+                    size_t njobs, int chunkSize, int warehouseFactor,
+                    bool fullWaveNoise, bool splitByChannel,
+                    bool platformNoiseDisabled, bool legNoiseDisabled,
+                    bool rebuildScene, bool writeScene, bool lasOutput,
+                    bool las10, bool zipOutput, bool fixedIncidenceAngle,
+                    std::string gpsStartTime, double lasScale, int kdtType,
+                    size_t kdtJobs, size_t kdtGeomJobs, size_t sahLossNodes,
+                    bool const legacyEnergyModel) {
   // Info about execution arguments
   std::stringstream ss;
   ss << "surveyPath: \"" << surveyPath << "\"\n"
@@ -79,13 +61,13 @@ LidarSim::init(std::string surveyPath,
 
   // Load survey description from XML file:
   std::shared_ptr<XmlSurveyLoader> xmlreader =
-    std::make_shared<XmlSurveyLoader>(surveyPath, assetsPath, writeScene);
+      std::make_shared<XmlSurveyLoader>(surveyPath, assetsPath, writeScene);
   xmlreader->sceneLoader.kdtFactoryType = kdtType;
   xmlreader->sceneLoader.kdtNumJobs = kdtJobs;
   xmlreader->sceneLoader.kdtGeomJobs = kdtGeomJobs;
   xmlreader->sceneLoader.kdtSAHLossNodes = sahLossNodes;
   std::shared_ptr<Survey> survey =
-    xmlreader->load(legNoiseDisabled, rebuildScene);
+      xmlreader->load(legNoiseDisabled, rebuildScene);
   if (survey == nullptr) {
     logging::ERR("Failed to load survey!");
     exit(-1);
@@ -101,7 +83,8 @@ LidarSim::init(std::string surveyPath,
 
   // Build main facade for File Management System, associated to the survey
   std::shared_ptr<fms::FMSFacade> fms = fms::FMSFacadeFactory().buildFacade(
-    outputPath, lasScale, lasOutput, las10, zipOutput, splitByChannel, *survey);
+      outputPath, lasScale, lasOutput, las10, zipOutput, splitByChannel,
+      *survey);
 
   // Build thread pool for parallel computation
   /*
@@ -111,29 +94,22 @@ LidarSim::init(std::string surveyPath,
   unsigned numSysThreads = std::thread::hardware_concurrency();
   std::size_t const poolSize = (njobs == 0) ? numSysThreads - 1 : njobs - 1;
   PulseThreadPoolFactory ptpf(
-    parallelizationStrategy,
-    poolSize,
-    survey->scanner->getDetector()->cfg_device_accuracy_m,
-    chunkSize,
-    warehouseFactor);
+      parallelizationStrategy, poolSize,
+      survey->scanner->getDetector()->cfg_device_accuracy_m, chunkSize,
+      warehouseFactor);
   std::shared_ptr<PulseThreadPoolInterface> pulseThreadPool =
-    ptpf.makePulseThreadPool();
+      ptpf.makePulseThreadPool();
 
   // Build the survey playback simulation itself
-  std::shared_ptr<SurveyPlayback> playback =
-    std::make_shared<SurveyPlayback>(survey,
-                                     fms,
-                                     parallelizationStrategy,
-                                     pulseThreadPool,
-                                     std::abs(chunkSize),
-                                     gpsStartTime,
-                                     legacyEnergyModel);
+  std::shared_ptr<SurveyPlayback> playback = std::make_shared<SurveyPlayback>(
+      survey, fms, parallelizationStrategy, pulseThreadPool,
+      std::abs(chunkSize), gpsStartTime, legacyEnergyModel);
 
   // Print a startup notice if snap-to-surface is enabled on any device.
   std::size_t snapToSurfaceEnabledCount = 0;
   std::size_t const numDevices = survey->scanner->getNumDevices();
   for (std::size_t devIdx = 0; devIdx < numDevices; ++devIdx) {
-    FWFSettings const& fwfSettings = survey->scanner->getFWFSettings(devIdx);
+    FWFSettings const &fwfSettings = survey->scanner->getFWFSettings(devIdx);
     if (fwfSettings.snapToSurface && fwfSettings.beamSampleQuality > 1) {
       ++snapToSurfaceEnabledCount;
     }
@@ -141,12 +117,12 @@ LidarSim::init(std::string surveyPath,
   if (snapToSurfaceEnabledCount > 0) {
     if (snapToSurfaceEnabledCount == numDevices) {
       std::cout << "snapToSurface is True (survey-level: "
-                << snapToSurfaceEnabledCount << "/" << numDevices
-                << " devices)" << std::endl; // LCOV_EXCL_LINE
+                << snapToSurfaceEnabledCount << "/" << numDevices << " devices)"
+                << std::endl; // LCOV_EXCL_LINE
     } else {
       std::cout << "snapToSurface is True (device-level: "
-                << snapToSurfaceEnabledCount << "/" << numDevices
-                << " devices)" << std::endl; // LCOV_EXCL_LINE
+                << snapToSurfaceEnabledCount << "/" << numDevices << " devices)"
+                << std::endl; // LCOV_EXCL_LINE
     }
   }
 
@@ -165,9 +141,7 @@ LidarSim::init(std::string surveyPath,
   release(playback);
 }
 
-void
-LidarSim::release(std::shared_ptr<SurveyPlayback> sp)
-{
+void LidarSim::release(std::shared_ptr<SurveyPlayback> sp) {
   // Release scanner
   std::shared_ptr<Scanner> sc = sp->mSurvey->scanner;
   sc->randGen1 = nullptr;
@@ -192,5 +166,5 @@ LidarSim::release(std::shared_ptr<SurveyPlayback> sp)
   sp->mSurvey = nullptr;
 }
 
-}
-}
+} // namespace main
+} // namespace helios

--- a/src/main/LidarSim.cpp
+++ b/src/main/LidarSim.cpp
@@ -129,6 +129,27 @@ LidarSim::init(std::string surveyPath,
                                      gpsStartTime,
                                      legacyEnergyModel);
 
+  // Print a startup notice if snap-to-surface is enabled on any device.
+  std::size_t snapToSurfaceEnabledCount = 0;
+  std::size_t const numDevices = survey->scanner->getNumDevices();
+  for (std::size_t devIdx = 0; devIdx < numDevices; ++devIdx) {
+    FWFSettings const& fwfSettings = survey->scanner->getFWFSettings(devIdx);
+    if (fwfSettings.snapToSurface && fwfSettings.beamSampleQuality > 1) {
+      ++snapToSurfaceEnabledCount;
+    }
+  }
+  if (snapToSurfaceEnabledCount > 0) {
+    if (snapToSurfaceEnabledCount == numDevices) {
+      std::cout << "snapToSurface is True (survey-level: "
+                << snapToSurfaceEnabledCount << "/" << numDevices
+                << " devices)" << std::endl;
+    } else {
+      std::cout << "snapToSurface is True (device-level: "
+                << snapToSurfaceEnabledCount << "/" << numDevices
+                << " devices)" << std::endl;
+    }
+  }
+
   // Start simulation
   logging::INFO("Running simulation...");
   TimeWatcher tw;

--- a/src/main/LidarSim.cpp
+++ b/src/main/LidarSim.cpp
@@ -142,11 +142,11 @@ LidarSim::init(std::string surveyPath,
     if (snapToSurfaceEnabledCount == numDevices) {
       std::cout << "snapToSurface is True (survey-level: "
                 << snapToSurfaceEnabledCount << "/" << numDevices
-                << " devices)" << std::endl;
+                << " devices)" << std::endl; // LCOV_EXCL_LINE
     } else {
       std::cout << "snapToSurface is True (device-level: "
                 << snapToSurfaceEnabledCount << "/" << numDevices
-                << " devices)" << std::endl;
+                << " devices)" << std::endl; // LCOV_EXCL_LINE
     }
   }
 

--- a/src/scanner/FWFSettings.h
+++ b/src/scanner/FWFSettings.h
@@ -67,7 +67,7 @@ public:
    * @brief Snap waveform return to closest surface hit instead of
    *  Gaussian-fitted peak point, eliminating angle-dependent slant bias
    */
-  bool snapToSurface = false;
+  bool snapToSurface = false; // LCOV_EXCL_LINE
 
   // ***  CONSTRUCTION / DESTRUCTION  *** //
   // ************************************ //
@@ -98,7 +98,7 @@ public:
        << "beamSampleQuality = " << beamSampleQuality << "\n"
        << "winSize_ns = " << winSize_ns << "\n"
        << "maxFullwaveRange_ns = " << maxFullwaveRange_ns << "\n"
-       << "snapToSurface = " << snapToSurface << "\n";
+       << "snapToSurface = " << snapToSurface << "\n"; // LCOV_EXCL_LINE
     return ss.str();
   }
   /**

--- a/src/scanner/FWFSettings.h
+++ b/src/scanner/FWFSettings.h
@@ -9,7 +9,8 @@
 /**
  * @brief Full Waveform settings
  */
-class FWFSettings : public Asset {
+class FWFSettings : public Asset
+{
 
 public:
   // ***  ATTRIBUTES  *** //
@@ -81,7 +82,8 @@ public:
    * @brief Obtain the string representation of the scanner settings
    * @return String representing the scanner settings
    */
-  virtual inline std::string toString() const {
+  virtual inline std::string toString() const
+  {
     std::stringstream ss;
     ss << "FWFSettings \"" << id << "\":\n"
        << "binSize_ns = " << binSize_ns << "\n"
@@ -102,8 +104,9 @@ public:
   /**
    * @brief Overload of << operator for output streams
    */
-  friend std::ostream &operator<<(std::ostream &out,
-                                  const FWFSettings &settings) {
+  friend std::ostream& operator<<(std::ostream& out,
+                                  const FWFSettings& settings)
+  {
     out << settings.toString();
     return out;
   }

--- a/src/scanner/FWFSettings.h
+++ b/src/scanner/FWFSettings.h
@@ -9,8 +9,7 @@
 /**
  * @brief Full Waveform settings
  */
-class FWFSettings : public Asset
-{
+class FWFSettings : public Asset {
 
 public:
   // ***  ATTRIBUTES  *** //
@@ -82,8 +81,7 @@ public:
    * @brief Obtain the string representation of the scanner settings
    * @return String representing the scanner settings
    */
-  virtual inline std::string toString() const
-  {
+  virtual inline std::string toString() const {
     std::stringstream ss;
     ss << "FWFSettings \"" << id << "\":\n"
        << "binSize_ns = " << binSize_ns << "\n"
@@ -104,9 +102,8 @@ public:
   /**
    * @brief Overload of << operator for output streams
    */
-  friend std::ostream& operator<<(std::ostream& out,
-                                  const FWFSettings& settings)
-  {
+  friend std::ostream &operator<<(std::ostream &out,
+                                  const FWFSettings &settings) {
     out << settings.toString();
     return out;
   }

--- a/src/scanner/FWFSettings.h
+++ b/src/scanner/FWFSettings.h
@@ -63,6 +63,11 @@ public:
    * @brief Max full wave range (nanoseconds)
    */
   double maxFullwaveRange_ns = 0.0;
+  /**
+   * @brief Snap waveform return to closest surface hit instead of
+   *  Gaussian-fitted peak point, eliminating angle-dependent slant bias
+   */
+  bool snapToSurface = false;
 
   // ***  CONSTRUCTION / DESTRUCTION  *** //
   // ************************************ //
@@ -92,7 +97,8 @@ public:
        << "pulseLength_ns = " << pulseLength_ns << "\n"
        << "beamSampleQuality = " << beamSampleQuality << "\n"
        << "winSize_ns = " << winSize_ns << "\n"
-       << "maxFullwaveRange_ns = " << maxFullwaveRange_ns << "\n";
+       << "maxFullwaveRange_ns = " << maxFullwaveRange_ns << "\n"
+       << "snapToSurface = " << snapToSurface << "\n";
     return ss.str();
   }
   /**

--- a/src/scanner/detector/FullWaveformPulseRunnable.cpp
+++ b/src/scanner/detector/FullWaveformPulseRunnable.cpp
@@ -73,8 +73,9 @@ FullWaveformPulseRunnable::operator()(
   map<double, double> reflections;
   vector<RaySceneIntersection> intersects;
   std::vector<DiscreteSubrayReturn> discreteSubrayReturns;
+  FWFSettings const& fwfSettings = scanner->getFWFSettings(pulse.getDeviceIndex());
   bool const collectDiscreteSubrayReturns =
-    scanner->getFWFSettings(pulse.getDeviceIndex()).snapToSurface;
+    fwfSettings.snapToSurface && fwfSettings.beamSampleQuality > 1;
 #if DATA_ANALYTICS >= 2
   std::vector<std::vector<double>> calcIntensityRecords;
   std::vector<std::vector<int>> calcIntensityIndices;
@@ -544,8 +545,9 @@ FullWaveformPulseRunnable::digestFullWaveform(
 
   // Surface snapping: snap returns to actual mesh hit points, eliminating
   // angle-dependent slant bias in full waveform Gaussian peak distances
+  FWFSettings const& fwfSettings = scanner->getFWFSettings(pulse.getDeviceIndex());
   bool const snapToSurface =
-    scanner->getFWFSettings(pulse.getDeviceIndex()).snapToSurface;
+    fwfSettings.snapToSurface && fwfSettings.beamSampleQuality > 1;
   vector<double> const& timeWave = scanner->getTimeWave(pulse.getDeviceIndex());
   bool const canSnapToSurface =
     snapToSurface && !discreteSubrayReturns.empty() && !timeWave.empty();

--- a/src/scanner/detector/FullWaveformPulseRunnable.cpp
+++ b/src/scanner/detector/FullWaveformPulseRunnable.cpp
@@ -5,6 +5,7 @@
 #include "logging.hpp"
 
 #define _USE_MATH_DEFINES
+#include <algorithm>
 #include <cmath>
 
 #include "maths/Rotation.h"
@@ -71,13 +72,15 @@ FullWaveformPulseRunnable::operator()(
   // Ray casting (find intersections)
   map<double, double> reflections;
   vector<RaySceneIntersection> intersects;
+  std::vector<DiscreteSubrayReturn> discreteSubrayReturns;
 #if DATA_ANALYTICS >= 2
   std::vector<std::vector<double>> calcIntensityRecords;
   std::vector<std::vector<int>> calcIntensityIndices;
 #endif
   computeSubrays(intersectionHandlingNoiseSource,
                  reflections,
-                 intersects
+                 intersects,
+                 discreteSubrayReturns
 #if DATA_ANALYTICS >= 2
                  ,
                  calcIntensityRecords,
@@ -98,7 +101,8 @@ FullWaveformPulseRunnable::operator()(
                       randGen2,
                       beamDir,
                       reflections,
-                      intersects
+                      intersects,
+                      discreteSubrayReturns
 #if DATA_ANALYTICS >= 2
                       ,
                       calcIntensityRecords,
@@ -120,7 +124,8 @@ void
 FullWaveformPulseRunnable::computeSubrays(
   NoiseSource<double>& intersectionHandlingNoiseSource,
   std::map<double, double>& reflections,
-  vector<RaySceneIntersection>& intersects
+  vector<RaySceneIntersection>& intersects,
+  std::vector<DiscreteSubrayReturn>& discreteSubrayReturns
 #if DATA_ANALYTICS >= 2
   ,
   std::vector<std::vector<double>>& calcIntensityRecords,
@@ -144,7 +149,8 @@ FullWaveformPulseRunnable::computeSubrays(
                    subrayRadiusStep,
                    intersectionHandlingNoiseSource,
                    reflections,
-                   intersects
+                   intersects,
+                   discreteSubrayReturns
 #if DATA_ANALYTICS >= 2
                    ,
                    subrayHit,
@@ -170,7 +176,8 @@ FullWaveformPulseRunnable::handleSubray(
   int const subrayRadiusStep,
   NoiseSource<double>& intersectionHandlingNoiseSource,
   map<double, double>& reflections,
-  vector<RaySceneIntersection>& intersects
+  vector<RaySceneIntersection>& intersects,
+  std::vector<DiscreteSubrayReturn>& discreteSubrayReturns
 #if DATA_ANALYTICS >= 2
   ,
   bool& subrayHit,
@@ -284,7 +291,12 @@ FullWaveformPulseRunnable::handleSubray(
       if (!rayContinues) { // If ray is not continuing
         // Then register hit by default
         reflections.insert(pair<double, double>(distance, intensity));
+        DiscreteSubrayReturn dsr;
+        dsr.distance = distance;
+        dsr.intensity = intensity;
+        dsr.intersectsIndex = intersects.size();
         intersects.push_back(*intersect);
+        discreteSubrayReturns.push_back(dsr);
       }
 #if DATA_ANALYTICS >= 2
       std::vector<double>& calcIntensityRecord = calcIntensityRecords.back();
@@ -311,7 +323,8 @@ FullWaveformPulseRunnable::digestIntersections(
   RandomnessGenerator<double>& randGen2,
   glm::dvec3& beamDir,
   std::map<double, double>& reflections,
-  vector<RaySceneIntersection>& intersects
+  vector<RaySceneIntersection>& intersects,
+  std::vector<DiscreteSubrayReturn> const& discreteSubrayReturns
 #if DATA_ANALYTICS >= 2
   ,
   vector<vector<double>>& calcIntensityRecords,
@@ -375,7 +388,8 @@ FullWaveformPulseRunnable::digestIntersections(
                      nsPerBin,
                      numFullwaveBins,
                      peakIntensityIndex,
-                     minHitTime_ns
+                     minHitTime_ns,
+                     discreteSubrayReturns
 #if DATA_ANALYTICS >= 2
                      ,
                      calcIntensityRecords,
@@ -488,7 +502,8 @@ FullWaveformPulseRunnable::digestFullWaveform(
   double const nsPerBin,
   int const numFullwaveBins,
   int const peakIntensityIndex,
-  double const minHitTime_ns
+  double const minHitTime_ns,
+  std::vector<DiscreteSubrayReturn> const& discreteSubrayReturns
 #if DATA_ANALYTICS >= 2
   ,
   std::vector<std::vector<double>>& calcIntensityRecords,
@@ -511,6 +526,43 @@ FullWaveformPulseRunnable::digestFullWaveform(
 
   double echo_width = 0.0;
 
+  // Pre-compute per-intersection distances for use in intersection matching
+  std::vector<double> intersectDistances;
+  intersectDistances.reserve(intersects.size());
+  for (RaySceneIntersection const& isc : intersects) {
+    intersectDistances.push_back(glm::distance(isc.point, pulse.getOriginRef()));
+  }
+
+  // Surface snapping: snap returns to actual mesh hit points, eliminating
+  // angle-dependent slant bias in full waveform Gaussian peak distances
+  bool const snapToSurface =
+    scanner->getFWFSettings(pulse.getDeviceIndex()).snapToSurface;
+  vector<double> const& timeWave = scanner->getTimeWave(pulse.getDeviceIndex());
+  bool const canSnapToSurface =
+    snapToSurface && !discreteSubrayReturns.empty() && !timeWave.empty();
+  std::vector<std::vector<std::size_t>> contributorsByBin;
+  if (canSnapToSurface) {
+    contributorsByBin.resize(numFullwaveBins);
+    for (std::size_t k = 0; k < discreteSubrayReturns.size(); ++k) {
+      DiscreteSubrayReturn const& dsr = discreteSubrayReturns[k];
+      double const wavePeakTime_ns = dsr.distance / SPEEDofLIGHT_mPerNanosec;
+      int const binStart = std::max(
+        (((int)((wavePeakTime_ns - minHitTime_ns) / nsPerBin)) -
+         peakIntensityIndex),
+        0);
+      if (binStart >= numFullwaveBins)
+        continue;
+      int const binEnd =
+        std::min(binStart + (int)timeWave.size() - 1, numFullwaveBins - 1);
+      for (int bin = binStart; bin <= binEnd; ++bin) {
+        int const waveBinIdx = bin - binStart;
+        if (timeWave[waveBinIdx] * dsr.intensity > 0.0) {
+          contributorsByBin[bin].push_back(k);
+        }
+      }
+    }
+  }
+
 #if DATA_ANALYTICS >= 2
   std::unordered_set<std::size_t> capturedIndices;
 #endif
@@ -526,28 +578,56 @@ FullWaveformPulseRunnable::digestFullWaveform(
     // Build list of objects that produced this return
     double minDifference = numeric_limits<double>::max();
     shared_ptr<RaySceneIntersection> closestIntersection = nullptr;
+    std::size_t closestIntersectionIdx = 0;
 
-#ifdef DATA_ANALYTICS
-    size_t intersectionIdx = 0;
-    size_t closestIntersectionIdx = 0;
-#endif
-    for (RaySceneIntersection intersect : intersects) {
-      double const intersectDist =
-        glm::distance(intersect.point, pulse.getOriginRef());
-      double const absDistDiff = std::fabs(intersectDist - distance);
-
-      if (absDistDiff < minDifference) {
-        minDifference = absDistDiff;
-        closestIntersection = make_shared<RaySceneIntersection>(intersect);
-#ifdef DATA_ANALYTICS
-        closestIntersectionIdx = intersectionIdx;
-#endif
+    // First priority: surface snapping — find the subray hit whose actual
+    // intersection point is closest to the Gaussian-predicted point
+    if (canSnapToSurface && i < numFullwaveBins) {
+      std::vector<std::size_t> const& peakContributors = contributorsByBin[i];
+      if (!peakContributors.empty()) {
+        glm::dvec3 const centralPredictedPoint =
+          pulse.getOriginRef() + beamDir * distance;
+        double minPointDifference = numeric_limits<double>::max();
+        std::size_t bestDiscreteIdx = peakContributors.front();
+        for (std::size_t const discreteIdx : peakContributors) {
+          DiscreteSubrayReturn const& candidate =
+            discreteSubrayReturns[discreteIdx];
+          std::size_t const candidateIntersectIdx = candidate.intersectsIndex;
+          if (candidateIntersectIdx >= intersects.size())
+            continue;
+          double const pointDifference = glm::distance(
+            intersects[candidateIntersectIdx].point, centralPredictedPoint);
+          if (pointDifference < minPointDifference) {
+            minPointDifference = pointDifference;
+            bestDiscreteIdx = discreteIdx;
+          }
+        }
+        DiscreteSubrayReturn const& bestDsr =
+          discreteSubrayReturns[bestDiscreteIdx];
+        distance = bestDsr.distance;
+        closestIntersectionIdx = bestDsr.intersectsIndex;
+        if (closestIntersectionIdx < intersects.size()) {
+          closestIntersection = make_shared<RaySceneIntersection>(
+            intersects[closestIntersectionIdx]);
+        }
       }
-#ifdef DATA_ANALYTICS
-      ++intersectionIdx;
-#endif
+    }
+    // Fallback: standard closest-by-distance
+    if (closestIntersection == nullptr) {
+      for (std::size_t iIdx = 0; iIdx < intersects.size(); ++iIdx) {
+        double const absDistDiff =
+          std::fabs(intersectDistances[iIdx] - distance);
+        if (absDistDiff < minDifference) {
+          minDifference = absDistDiff;
+          closestIntersection =
+            make_shared<RaySceneIntersection>(intersects[iIdx]);
+          closestIntersectionIdx = iIdx;
+        }
+      }
     }
 
+    // Compute measurement beam direction from actual surface hit when snapping
+    glm::dvec3 measurementBeamDirection = beamDir;
     string hitObject;
     int classification = 0;
     if (closestIntersection != nullptr) {
@@ -558,6 +638,16 @@ FullWaveformPulseRunnable::digestFullWaveform(
         hitObject = hitObject.substr(5);
       }
       classification = closestIntersection->prim->material->classification;
+      if (canSnapToSurface) {
+        glm::dvec3 const discreteDirection =
+          closestIntersection->point - pulse.getOriginRef();
+        double const discreteDirectionNorm = glm::length(discreteDirection);
+        if (discreteDirectionNorm > 0.0) {
+          measurementBeamDirection =
+            discreteDirection / discreteDirectionNorm;
+          distance = discreteDirectionNorm;
+        }
+      }
     }
 
     // Add distance error (mechanical range error)
@@ -570,7 +660,7 @@ FullWaveformPulseRunnable::digestFullWaveform(
     tmp.devIdx = devIdx;
     tmp.devId = scanner->getDeviceId(devIdx);
     tmp.beamOrigin = pulse.getOrigin();
-    tmp.beamDirection = beamDir;
+    tmp.beamDirection = measurementBeamDirection;
     tmp.distance = distance;
     tmp.echo_width = echo_width;
     tmp.intensity = fullwave.at(i);

--- a/src/scanner/detector/FullWaveformPulseRunnable.cpp
+++ b/src/scanner/detector/FullWaveformPulseRunnable.cpp
@@ -73,6 +73,8 @@ FullWaveformPulseRunnable::operator()(
   map<double, double> reflections;
   vector<RaySceneIntersection> intersects;
   std::vector<DiscreteSubrayReturn> discreteSubrayReturns;
+  bool const collectDiscreteSubrayReturns =
+    scanner->getFWFSettings(pulse.getDeviceIndex()).snapToSurface;
 #if DATA_ANALYTICS >= 2
   std::vector<std::vector<double>> calcIntensityRecords;
   std::vector<std::vector<int>> calcIntensityIndices;
@@ -80,7 +82,8 @@ FullWaveformPulseRunnable::operator()(
   computeSubrays(intersectionHandlingNoiseSource,
                  reflections,
                  intersects,
-                 discreteSubrayReturns
+                 discreteSubrayReturns,
+                 collectDiscreteSubrayReturns
 #if DATA_ANALYTICS >= 2
                  ,
                  calcIntensityRecords,
@@ -125,7 +128,8 @@ FullWaveformPulseRunnable::computeSubrays(
   NoiseSource<double>& intersectionHandlingNoiseSource,
   std::map<double, double>& reflections,
   vector<RaySceneIntersection>& intersects,
-  std::vector<DiscreteSubrayReturn>& discreteSubrayReturns
+  std::vector<DiscreteSubrayReturn>& discreteSubrayReturns,
+  bool const collectDiscreteSubrayReturns
 #if DATA_ANALYTICS >= 2
   ,
   std::vector<std::vector<double>>& calcIntensityRecords,
@@ -150,7 +154,8 @@ FullWaveformPulseRunnable::computeSubrays(
                    intersectionHandlingNoiseSource,
                    reflections,
                    intersects,
-                   discreteSubrayReturns
+                   discreteSubrayReturns,
+                   collectDiscreteSubrayReturns
 #if DATA_ANALYTICS >= 2
                    ,
                    subrayHit,
@@ -177,7 +182,8 @@ FullWaveformPulseRunnable::handleSubray(
   NoiseSource<double>& intersectionHandlingNoiseSource,
   map<double, double>& reflections,
   vector<RaySceneIntersection>& intersects,
-  std::vector<DiscreteSubrayReturn>& discreteSubrayReturns
+  std::vector<DiscreteSubrayReturn>& discreteSubrayReturns,
+  bool const collectDiscreteSubrayReturns
 #if DATA_ANALYTICS >= 2
   ,
   bool& subrayHit,
@@ -291,12 +297,15 @@ FullWaveformPulseRunnable::handleSubray(
       if (!rayContinues) { // If ray is not continuing
         // Then register hit by default
         reflections.insert(pair<double, double>(distance, intensity));
-        DiscreteSubrayReturn dsr;
-        dsr.distance = distance;
-        dsr.intensity = intensity;
-        dsr.intersectsIndex = intersects.size();
+        std::size_t const intersectsIndex = intersects.size();
         intersects.push_back(*intersect);
-        discreteSubrayReturns.push_back(dsr);
+        if (collectDiscreteSubrayReturns) {
+          DiscreteSubrayReturn dsr;
+          dsr.distance = distance;
+          dsr.intensity = intensity;
+          dsr.intersectsIndex = intersectsIndex;
+          discreteSubrayReturns.push_back(dsr);
+        }
       }
 #if DATA_ANALYTICS >= 2
       std::vector<double>& calcIntensityRecord = calcIntensityRecords.back();

--- a/src/scanner/detector/FullWaveformPulseRunnable.cpp
+++ b/src/scanner/detector/FullWaveformPulseRunnable.cpp
@@ -303,7 +303,7 @@ FullWaveformPulseRunnable::handleSubray(
         intersects.push_back(*intersect);
         if (collectDiscreteSubrayReturns) {
           DiscreteSubrayReturn dsr;
-          dsr.distance = distance;
+          dsr.subrayRadiusStep = subrayRadiusStep;
           dsr.intensity = intensity;
           dsr.intersectsIndex = intersectsIndex;
           discreteSubrayReturns.push_back(dsr);
@@ -554,28 +554,6 @@ FullWaveformPulseRunnable::digestFullWaveform(
   vector<double> const& timeWave = scanner->getTimeWave(pulse.getDeviceIndex());
   bool const canSnapToSurface =
     snapToSurface && !discreteSubrayReturns.empty() && !timeWave.empty();
-  std::vector<std::vector<std::size_t>> contributorsByBin;
-  if (canSnapToSurface) {
-    contributorsByBin.resize(numFullwaveBins);
-    for (std::size_t k = 0; k < discreteSubrayReturns.size(); ++k) {
-      DiscreteSubrayReturn const& dsr = discreteSubrayReturns[k];
-      double const wavePeakTime_ns = dsr.distance / SPEEDofLIGHT_mPerNanosec;
-      int const binStart =
-        std::max((((int)((wavePeakTime_ns - minHitTime_ns) / nsPerBin)) -
-                  peakIntensityIndex),
-                 0);
-      if (binStart >= numFullwaveBins)
-        continue;
-      int const binEnd =
-        std::min(binStart + (int)timeWave.size() - 1, numFullwaveBins - 1);
-      for (int bin = binStart; bin <= binEnd; ++bin) {
-        int const waveBinIdx = bin - binStart;
-        if (timeWave[waveBinIdx] * dsr.intensity > 0.0) {
-          contributorsByBin[bin].push_back(k);
-        }
-      }
-    }
-  }
 
 #if DATA_ANALYTICS >= 2
   std::unordered_set<std::size_t> capturedIndices;
@@ -594,36 +572,52 @@ FullWaveformPulseRunnable::digestFullWaveform(
     shared_ptr<RaySceneIntersection> closestIntersection = nullptr;
     std::size_t closestIntersectionIdx = 0;
 
-    // First priority: surface snapping — find the subray hit whose actual
-    // intersection point is closest to the Gaussian-predicted point
+    // First priority: surface snapping — prefer the innermost contributing
+    // subray ring, then the closest hit within that ring.
     if (canSnapToSurface && i < numFullwaveBins) {
-      std::vector<std::size_t> const& peakContributors = contributorsByBin[i];
-      if (!peakContributors.empty()) {
-        glm::dvec3 const centralPredictedPoint =
-          pulse.getOriginRef() + beamDir * distance;
-        double minPointDifference = numeric_limits<double>::max();
-        std::size_t bestDiscreteIdx = peakContributors.front();
-        for (std::size_t const discreteIdx : peakContributors) {
-          DiscreteSubrayReturn const& candidate =
-            discreteSubrayReturns[discreteIdx];
-          std::size_t const candidateIntersectIdx = candidate.intersectsIndex;
-          if (candidateIntersectIdx >= intersects.size())
-            continue;
-          double const pointDifference = glm::distance(
-            intersects[candidateIntersectIdx].point, centralPredictedPoint);
-          if (pointDifference < minPointDifference) {
-            minPointDifference = pointDifference;
-            bestDiscreteIdx = discreteIdx;
-          }
+      int bestRadiusStep = numeric_limits<int>::max();
+      double bestRadiusDistance = numeric_limits<double>::max();
+      bool foundValidCandidate = false;
+      for (std::size_t discreteIdx = 0;
+           discreteIdx < discreteSubrayReturns.size();
+           ++discreteIdx) {
+        DiscreteSubrayReturn const& candidate =
+          discreteSubrayReturns[discreteIdx];
+        std::size_t const candidateIntersectIdx = candidate.intersectsIndex;
+        if (candidateIntersectIdx >= intersects.size())
+          continue;
+
+        double const candidateDistance =
+          intersectDistances[candidateIntersectIdx];
+        double const wavePeakTime_ns =
+          candidateDistance / SPEEDofLIGHT_mPerNanosec;
+        int const binStart =
+          std::max((((int)((wavePeakTime_ns - minHitTime_ns) / nsPerBin)) -
+                    peakIntensityIndex),
+                   0);
+        if (binStart >= numFullwaveBins || i < binStart)
+          continue;
+
+        int const waveBinIdx = i - binStart;
+        if (waveBinIdx < 0 || waveBinIdx >= (int)timeWave.size())
+          continue;
+        if (timeWave[waveBinIdx] * candidate.intensity <= 0.0)
+          continue;
+
+        if (!foundValidCandidate ||
+            candidate.subrayRadiusStep < bestRadiusStep ||
+            (candidate.subrayRadiusStep == bestRadiusStep &&
+             candidateDistance < bestRadiusDistance)) {
+          foundValidCandidate = true;
+          bestRadiusStep = candidate.subrayRadiusStep;
+          bestRadiusDistance = candidateDistance;
+          closestIntersectionIdx = candidateIntersectIdx;
         }
-        DiscreteSubrayReturn const& bestDsr =
-          discreteSubrayReturns[bestDiscreteIdx];
-        distance = bestDsr.distance;
-        closestIntersectionIdx = bestDsr.intersectsIndex;
-        if (closestIntersectionIdx < intersects.size()) {
-          closestIntersection = make_shared<RaySceneIntersection>(
-            intersects[closestIntersectionIdx]);
-        }
+      }
+      if (foundValidCandidate && closestIntersectionIdx < intersects.size()) {
+        distance = intersectDistances[closestIntersectionIdx];
+        closestIntersection =
+          make_shared<RaySceneIntersection>(intersects[closestIntersectionIdx]);
       }
     }
     // Fallback: standard closest-by-distance

--- a/src/scanner/detector/FullWaveformPulseRunnable.cpp
+++ b/src/scanner/detector/FullWaveformPulseRunnable.cpp
@@ -73,7 +73,8 @@ FullWaveformPulseRunnable::operator()(
   map<double, double> reflections;
   vector<RaySceneIntersection> intersects;
   std::vector<DiscreteSubrayReturn> discreteSubrayReturns;
-  FWFSettings const& fwfSettings = scanner->getFWFSettings(pulse.getDeviceIndex());
+  FWFSettings const& fwfSettings =
+    scanner->getFWFSettings(pulse.getDeviceIndex());
   bool const collectDiscreteSubrayReturns =
     fwfSettings.snapToSurface && fwfSettings.beamSampleQuality > 1;
 #if DATA_ANALYTICS >= 2
@@ -540,12 +541,14 @@ FullWaveformPulseRunnable::digestFullWaveform(
   std::vector<double> intersectDistances;
   intersectDistances.reserve(intersects.size());
   for (RaySceneIntersection const& isc : intersects) {
-    intersectDistances.push_back(glm::distance(isc.point, pulse.getOriginRef()));
+    intersectDistances.push_back(
+      glm::distance(isc.point, pulse.getOriginRef()));
   }
 
   // Surface snapping: snap returns to actual mesh hit points, eliminating
   // angle-dependent slant bias in full waveform Gaussian peak distances
-  FWFSettings const& fwfSettings = scanner->getFWFSettings(pulse.getDeviceIndex());
+  FWFSettings const& fwfSettings =
+    scanner->getFWFSettings(pulse.getDeviceIndex());
   bool const snapToSurface =
     fwfSettings.snapToSurface && fwfSettings.beamSampleQuality > 1;
   vector<double> const& timeWave = scanner->getTimeWave(pulse.getDeviceIndex());
@@ -557,10 +560,10 @@ FullWaveformPulseRunnable::digestFullWaveform(
     for (std::size_t k = 0; k < discreteSubrayReturns.size(); ++k) {
       DiscreteSubrayReturn const& dsr = discreteSubrayReturns[k];
       double const wavePeakTime_ns = dsr.distance / SPEEDofLIGHT_mPerNanosec;
-      int const binStart = std::max(
-        (((int)((wavePeakTime_ns - minHitTime_ns) / nsPerBin)) -
-         peakIntensityIndex),
-        0);
+      int const binStart =
+        std::max((((int)((wavePeakTime_ns - minHitTime_ns) / nsPerBin)) -
+                  peakIntensityIndex),
+                 0);
       if (binStart >= numFullwaveBins)
         continue;
       int const binEnd =
@@ -654,8 +657,7 @@ FullWaveformPulseRunnable::digestFullWaveform(
           closestIntersection->point - pulse.getOriginRef();
         double const discreteDirectionNorm = glm::length(discreteDirection);
         if (discreteDirectionNorm > 0.0) {
-          measurementBeamDirection =
-            discreteDirection / discreteDirectionNorm;
+          measurementBeamDirection = discreteDirection / discreteDirectionNorm;
           distance = discreteDirectionNorm;
         }
       }

--- a/src/scanner/detector/FullWaveformPulseRunnable.h
+++ b/src/scanner/detector/FullWaveformPulseRunnable.h
@@ -18,6 +18,18 @@
 #include <vector>
 
 /**
+ * @brief Holds the result of a single subray intersection for use in
+ *  surface-snapping full waveform processing
+ * @see FullWaveformPulseRunnable
+ */
+struct DiscreteSubrayReturn
+{
+  double distance = 0.0;
+  double intensity = 0.0;
+  std::size_t intersectsIndex = 0; // Index into intersects array
+};
+
+/**
  * @brief Concrete implementation of abstract pulse runnable to compute full
  * waveform pulses
  *
@@ -75,7 +87,8 @@ private:
    */
   void computeSubrays(NoiseSource<double>& intersectionHandlingNoiseSource,
                       std::map<double, double>& reflections,
-                      vector<RaySceneIntersection>& intersects
+                      vector<RaySceneIntersection>& intersects,
+                      std::vector<DiscreteSubrayReturn>& discreteSubrayReturns
 #if DATA_ANALYTICS >= 2
                       ,
                       std::vector<std::vector<double>>& calcIntensityRecords,
@@ -96,7 +109,8 @@ private:
                     int const subrayRadiusStep,
                     NoiseSource<double>& intersectionHandlingNoiseSource,
                     std::map<double, double>& reflections,
-                    vector<RaySceneIntersection>& intersects
+                    vector<RaySceneIntersection>& intersects,
+                    std::vector<DiscreteSubrayReturn>& discreteSubrayReturns
 #if DATA_ANALYTICS >= 2
                     ,
                     bool& subrayHit,
@@ -124,7 +138,8 @@ private:
     RandomnessGenerator<double>& randGen2,
     glm::dvec3& beamDir,
     std::map<double, double>& reflections,
-    vector<RaySceneIntersection>& intersects
+    vector<RaySceneIntersection>& intersects,
+    std::vector<DiscreteSubrayReturn> const& discreteSubrayReturns
 #if DATA_ANALYTICS >= 2
     ,
     std::vector<std::vector<double>>& calcIntensityRecords,
@@ -195,7 +210,8 @@ private:
     double const nsPerBin,
     int const numFullwaveBins,
     int const peakIntensityIndex,
-    double const minHitTime_ns
+    double const minHitTime_ns,
+    std::vector<DiscreteSubrayReturn> const& discreteSubrayReturns
 #if DATA_ANALYTICS >= 2
     ,
     std::vector<std::vector<double>>& calcIntensityRecords,

--- a/src/scanner/detector/FullWaveformPulseRunnable.h
+++ b/src/scanner/detector/FullWaveformPulseRunnable.h
@@ -88,7 +88,8 @@ private:
   void computeSubrays(NoiseSource<double>& intersectionHandlingNoiseSource,
                       std::map<double, double>& reflections,
                       vector<RaySceneIntersection>& intersects,
-                      std::vector<DiscreteSubrayReturn>& discreteSubrayReturns
+                      std::vector<DiscreteSubrayReturn>& discreteSubrayReturns,
+                      bool const collectDiscreteSubrayReturns
 #if DATA_ANALYTICS >= 2
                       ,
                       std::vector<std::vector<double>>& calcIntensityRecords,
@@ -110,7 +111,8 @@ private:
                     NoiseSource<double>& intersectionHandlingNoiseSource,
                     std::map<double, double>& reflections,
                     vector<RaySceneIntersection>& intersects,
-                    std::vector<DiscreteSubrayReturn>& discreteSubrayReturns
+                    std::vector<DiscreteSubrayReturn>& discreteSubrayReturns,
+                    bool const collectDiscreteSubrayReturns
 #if DATA_ANALYTICS >= 2
                     ,
                     bool& subrayHit,

--- a/src/scanner/detector/FullWaveformPulseRunnable.h
+++ b/src/scanner/detector/FullWaveformPulseRunnable.h
@@ -17,13 +17,16 @@
 
 #include <vector>
 
+namespace HeliosTests {
+class SnapToSurfaceTest;
+}
+
 /**
  * @brief Holds the result of a single subray intersection for use in
  *  surface-snapping full waveform processing
  * @see FullWaveformPulseRunnable
  */
-struct DiscreteSubrayReturn
-{
+struct DiscreteSubrayReturn {
   double distance = 0.0;
   double intensity = 0.0;
   std::size_t intersectsIndex = 0; // Index into intersects array
@@ -35,8 +38,9 @@ struct DiscreteSubrayReturn
  *
  * @see AbstractPulseRunnable
  */
-class FullWaveformPulseRunnable : public AbstractPulseRunnable
-{
+class FullWaveformPulseRunnable : public AbstractPulseRunnable {
+  friend class HeliosTests::SnapToSurfaceTest;
+
 private:
   // ***  ATTRIBUTES  *** //
   // ******************** //
@@ -55,10 +59,8 @@ public:
    * @see SimulatedPulse
    */
   FullWaveformPulseRunnable(std::shared_ptr<Scanner> scanner,
-                            SimulatedPulse const& pulse)
-    : AbstractPulseRunnable(scanner, pulse)
-  {
-  }
+                            SimulatedPulse const &pulse)
+      : AbstractPulseRunnable(scanner, pulse) {}
 
   virtual ~FullWaveformPulseRunnable() {}
 
@@ -85,14 +87,14 @@ private:
    *  registered
    * @see FullWaveformPulseRunnable::handleSubray
    */
-  void computeSubrays(NoiseSource<double>& intersectionHandlingNoiseSource,
-                      std::map<double, double>& reflections,
-                      vector<RaySceneIntersection>& intersects,
-                      std::vector<DiscreteSubrayReturn>& discreteSubrayReturns,
+  void computeSubrays(NoiseSource<double> &intersectionHandlingNoiseSource,
+                      std::map<double, double> &reflections,
+                      vector<RaySceneIntersection> &intersects,
+                      std::vector<DiscreteSubrayReturn> &discreteSubrayReturns,
                       bool const collectDiscreteSubrayReturns
 #if DATA_ANALYTICS >= 2
                       ,
-                      std::vector<std::vector<double>>& calcIntensityRecords,
+                      std::vector<std::vector<double>> &calcIntensityRecords,
                       std::shared_ptr<HDA_PulseRecorder> pulseRecorder
 #endif
   );
@@ -106,18 +108,16 @@ private:
    *  to model the circumference (i.e., at which angle in the circle).
    * @see FullWaveformPulseRunnable::computeSubrays
    */
-  void handleSubray(Rotation const& subrayRotation,
-                    int const subrayRadiusStep,
-                    NoiseSource<double>& intersectionHandlingNoiseSource,
-                    std::map<double, double>& reflections,
-                    vector<RaySceneIntersection>& intersects,
-                    std::vector<DiscreteSubrayReturn>& discreteSubrayReturns,
+  void handleSubray(Rotation const &subrayRotation, int const subrayRadiusStep,
+                    NoiseSource<double> &intersectionHandlingNoiseSource,
+                    std::map<double, double> &reflections,
+                    vector<RaySceneIntersection> &intersects,
+                    std::vector<DiscreteSubrayReturn> &discreteSubrayReturns,
                     bool const collectDiscreteSubrayReturns
 #if DATA_ANALYTICS >= 2
                     ,
-                    bool& subrayHit,
-                    std::vector<double>& subraySimRecord,
-                    std::vector<std::vector<double>>& calcIntensityRecords
+                    bool &subrayHit, std::vector<double> &subraySimRecord,
+                    std::vector<std::vector<double>> &calcIntensityRecords
 #endif
   );
   /**
@@ -135,18 +135,17 @@ private:
    * @see FullWaveformPulseRunnable::exportOutput
    */
   void digestIntersections(
-    std::vector<std::vector<double>>& apMatrix,
-    RandomnessGenerator<double>& randGen,
-    RandomnessGenerator<double>& randGen2,
-    glm::dvec3& beamDir,
-    std::map<double, double>& reflections,
-    vector<RaySceneIntersection>& intersects,
-    std::vector<DiscreteSubrayReturn> const& discreteSubrayReturns
+      std::vector<std::vector<double>> &apMatrix,
+      RandomnessGenerator<double> &randGen,
+      RandomnessGenerator<double> &randGen2, glm::dvec3 &beamDir,
+      std::map<double, double> &reflections,
+      vector<RaySceneIntersection> &intersects,
+      std::vector<DiscreteSubrayReturn> const &discreteSubrayReturns
 #if DATA_ANALYTICS >= 2
-    ,
-    std::vector<std::vector<double>>& calcIntensityRecords,
-    std::vector<std::vector<int>>& calcIntensityIndices,
-    std::shared_ptr<HDA_PulseRecorder> pulseRecorder
+      ,
+      std::vector<std::vector<double>> &calcIntensityRecords,
+      std::vector<std::vector<int>> &calcIntensityIndices,
+      std::shared_ptr<HDA_PulseRecorder> pulseRecorder
 #endif
   );
   /**
@@ -155,9 +154,8 @@ private:
    * @param[out] maxHitDist_m Max hit distance will be stored here
    * @see FullWaveformPulseRunnable::digestIntersections
    */
-  void findMaxMinHitDistances(std::map<double, double>& reflections,
-                              double& minHitDist_m,
-                              double& maxHitDist_m);
+  void findMaxMinHitDistances(std::map<double, double> &reflections,
+                              double &minHitDist_m, double &maxHitDist_m);
   /**
    * @brief Initialize full waveform
    * While the vector is not strictly initialized in this function,
@@ -172,24 +170,20 @@ private:
    * @see FullWaveformPulseRunnable::digestIntersections
    */
   bool initializeFullWaveform(double const minHitDist_m,
-                              double const maxHitDist_m,
-                              double& minHitTime_ns,
-                              double& maxHitTime_ns,
-                              double& nsPerBin,
-                              double& distanceThreshold,
-                              int& peakIntensityIndex,
-                              int& numFullwaveBins);
+                              double const maxHitDist_m, double &minHitTime_ns,
+                              double &maxHitTime_ns, double &nsPerBin,
+                              double &distanceThreshold,
+                              int &peakIntensityIndex, int &numFullwaveBins);
   /**
    * @brief Populate a previously initialized full waveform vector
    * @param[out] fullwave Full waveform vector to be populated
    * @see FullWaveformPulseRunnable::digestIntersections
    * @see FullWaveformPulseRunnable::initializeFullWaveform
    */
-  void populateFullWaveform(std::map<double, double> const& reflections,
-                            std::vector<double>& fullwave,
+  void populateFullWaveform(std::map<double, double> const &reflections,
+                            std::vector<double> &fullwave,
                             double const distanceThreshold,
-                            double const minHitTime_ns,
-                            double const nsPerBin,
+                            double const minHitTime_ns, double const nsPerBin,
                             int const peakIntensityIndex);
   /**
    * @brief Digest a previously populated full waveform vector,
@@ -203,22 +197,18 @@ private:
    * @see Measurement
    */
   void digestFullWaveform(
-    std::vector<Measurement>& pointsMeasurement,
-    int& numReturns,
-    std::vector<std::vector<double>>& apMatrix,
-    std::vector<double> const& fullwave,
-    vector<RaySceneIntersection> const& intersects,
-    glm::dvec3 const& beamDir,
-    double const nsPerBin,
-    int const numFullwaveBins,
-    int const peakIntensityIndex,
-    double const minHitTime_ns,
-    std::vector<DiscreteSubrayReturn> const& discreteSubrayReturns
+      std::vector<Measurement> &pointsMeasurement, int &numReturns,
+      std::vector<std::vector<double>> &apMatrix,
+      std::vector<double> const &fullwave,
+      vector<RaySceneIntersection> const &intersects, glm::dvec3 const &beamDir,
+      double const nsPerBin, int const numFullwaveBins,
+      int const peakIntensityIndex, double const minHitTime_ns,
+      std::vector<DiscreteSubrayReturn> const &discreteSubrayReturns
 #if DATA_ANALYTICS >= 2
-    ,
-    std::vector<std::vector<double>>& calcIntensityRecords,
-    std::vector<std::vector<int>>& calcIntensityIndices,
-    std::shared_ptr<HDA_PulseRecorder> pulseRecorder
+      ,
+      std::vector<std::vector<double>> &calcIntensityRecords,
+      std::vector<std::vector<int>> &calcIntensityIndices,
+      std::shared_ptr<HDA_PulseRecorder> pulseRecorder
 #endif
   );
   /**
@@ -233,11 +223,9 @@ private:
    *  hit, i.e., true to skip the current iteration. False to proceed with
    *  the computation of the current iteration.
    */
-  bool handleFullWaveformBin(std::vector<double> const& fullwave,
-                             MarquardtFitter& fit,
-                             double& echoWidth,
-                             int const binIndex,
-                             int const winSize,
+  bool handleFullWaveformBin(std::vector<double> const &fullwave,
+                             MarquardtFitter &fit, double &echoWidth,
+                             int const binIndex, int const winSize,
                              double const nsPerBin);
   /**
    * @brief Export measurements and full waveform data
@@ -245,18 +233,16 @@ private:
    * @param[in] pointsMeasurement Point cloud data to export
    * @see FullWaveformPulseRunnable::digestIntersections
    */
-  void exportOutput(std::vector<double>& fullwave,
-                    int const numReturns,
-                    std::vector<Measurement>& pointsMeasurement,
-                    glm::dvec3 const& beamDir,
-                    double const minHitTime_ns,
+  void exportOutput(std::vector<double> &fullwave, int const numReturns,
+                    std::vector<Measurement> &pointsMeasurement,
+                    glm::dvec3 const &beamDir, double const minHitTime_ns,
                     double const maxHitTime_ns,
-                    RandomnessGenerator<double>& randGen,
-                    RandomnessGenerator<double>& randGen2
+                    RandomnessGenerator<double> &randGen,
+                    RandomnessGenerator<double> &randGen2
 #if DATA_ANALYTICS >= 2
                     ,
-                    std::vector<std::vector<double>>& calcIntensityRecords,
-                    std::vector<std::vector<int>>& calcIntensityIndices,
+                    std::vector<std::vector<double>> &calcIntensityRecords,
+                    std::vector<std::vector<int>> &calcIntensityIndices,
                     std::shared_ptr<HDA_PulseRecorder> pulseRecorder
 #endif
   );
@@ -271,17 +257,14 @@ private:
    * @param v The ray director vector
    * @return Intersection between the scene and given ray
    */
-  virtual std::shared_ptr<RaySceneIntersection> findIntersection(
-    std::vector<double> const& tMinMax,
-    glm::dvec3 const& o,
-    glm::dvec3 const& v) const;
+  virtual std::shared_ptr<RaySceneIntersection>
+  findIntersection(std::vector<double> const &tMinMax, glm::dvec3 const &o,
+                   glm::dvec3 const &v) const;
   /**
    * @brief Detect full waveform peaks
    */
-  bool detectPeak(int const i,
-                  int const win_size,
-                  std::vector<double> const& fullwave,
-                  double const eps);
+  bool detectPeak(int const i, int const win_size,
+                  std::vector<double> const &fullwave, double const eps);
 
   /**
    * @brief Capture full wave
@@ -297,15 +280,11 @@ private:
    * @param rg2 Randomness generator to be used to add noise to the full wave
    *  if requested
    */
-  void captureFullWave(std::vector<double>& fullwave,
-                       int const fullwaveIndex,
-                       double const min_time,
-                       double const max_time,
-                       glm::dvec3 const& beamOrigin,
-                       glm::dvec3 const& beamDir,
-                       double const gpstime,
-                       bool const fullWaveNoise,
-                       RandomnessGenerator<double>& rg2);
+  void captureFullWave(std::vector<double> &fullwave, int const fullwaveIndex,
+                       double const min_time, double const max_time,
+                       glm::dvec3 const &beamOrigin, glm::dvec3 const &beamDir,
+                       double const gpstime, bool const fullWaveNoise,
+                       RandomnessGenerator<double> &rg2);
 
   /**
    * @brief Check whether the ray/subray must be aborted or not depending
@@ -325,8 +304,7 @@ private:
    * @see Scene
    * @see AABB
    */
-  inline bool checkEarlyAbort(std::vector<double> const& tMinMax)
-  {
+  inline bool checkEarlyAbort(std::vector<double> const &tMinMax) {
     return tMinMax.empty() || (tMinMax[0] < 0 && tMinMax[1] <= 0);
   }
 
@@ -338,10 +316,9 @@ public:
    * due to compatibility reasons.
    * @see AbstractPulseRunnable::operator()
    */
-  void operator()() override
-  {
+  void operator()() override {
     throw HeliosException(
-      "FullWaveformPulseRunnable operator()() must not be used");
+        "FullWaveformPulseRunnable operator()() must not be used");
   }
   /**
    * @brief Full waveform pulse runnable functor
@@ -353,10 +330,10 @@ public:
    * intersection handling if necessary
    * @see AbstractPulseRunnable::operator()()
    */
-  void operator()(std::vector<std::vector<double>>& apMatrix,
-                  RandomnessGenerator<double>& randGen,
-                  RandomnessGenerator<double>& randGen2,
-                  NoiseSource<double>& intersectionHandlingNoiseSource
+  void operator()(std::vector<std::vector<double>> &apMatrix,
+                  RandomnessGenerator<double> &randGen,
+                  RandomnessGenerator<double> &randGen2,
+                  NoiseSource<double> &intersectionHandlingNoiseSource
 #if DATA_ANALYTICS >= 2
                   ,
                   std::shared_ptr<HDA_PulseRecorder> pulseRecorder

--- a/src/scanner/detector/FullWaveformPulseRunnable.h
+++ b/src/scanner/detector/FullWaveformPulseRunnable.h
@@ -28,7 +28,7 @@ class SnapToSurfaceTest;
  */
 struct DiscreteSubrayReturn
 {
-  double distance = 0.0;
+  int subrayRadiusStep = 0;
   double intensity = 0.0;
   std::size_t intersectsIndex = 0; // Index into intersects array
 };

--- a/src/scanner/detector/FullWaveformPulseRunnable.h
+++ b/src/scanner/detector/FullWaveformPulseRunnable.h
@@ -26,7 +26,8 @@ class SnapToSurfaceTest;
  *  surface-snapping full waveform processing
  * @see FullWaveformPulseRunnable
  */
-struct DiscreteSubrayReturn {
+struct DiscreteSubrayReturn
+{
   double distance = 0.0;
   double intensity = 0.0;
   std::size_t intersectsIndex = 0; // Index into intersects array
@@ -38,7 +39,8 @@ struct DiscreteSubrayReturn {
  *
  * @see AbstractPulseRunnable
  */
-class FullWaveformPulseRunnable : public AbstractPulseRunnable {
+class FullWaveformPulseRunnable : public AbstractPulseRunnable
+{
   friend class HeliosTests::SnapToSurfaceTest;
 
 private:
@@ -59,8 +61,10 @@ public:
    * @see SimulatedPulse
    */
   FullWaveformPulseRunnable(std::shared_ptr<Scanner> scanner,
-                            SimulatedPulse const &pulse)
-      : AbstractPulseRunnable(scanner, pulse) {}
+                            SimulatedPulse const& pulse)
+    : AbstractPulseRunnable(scanner, pulse)
+  {
+  }
 
   virtual ~FullWaveformPulseRunnable() {}
 
@@ -87,14 +91,14 @@ private:
    *  registered
    * @see FullWaveformPulseRunnable::handleSubray
    */
-  void computeSubrays(NoiseSource<double> &intersectionHandlingNoiseSource,
-                      std::map<double, double> &reflections,
-                      vector<RaySceneIntersection> &intersects,
-                      std::vector<DiscreteSubrayReturn> &discreteSubrayReturns,
+  void computeSubrays(NoiseSource<double>& intersectionHandlingNoiseSource,
+                      std::map<double, double>& reflections,
+                      vector<RaySceneIntersection>& intersects,
+                      std::vector<DiscreteSubrayReturn>& discreteSubrayReturns,
                       bool const collectDiscreteSubrayReturns
 #if DATA_ANALYTICS >= 2
                       ,
-                      std::vector<std::vector<double>> &calcIntensityRecords,
+                      std::vector<std::vector<double>>& calcIntensityRecords,
                       std::shared_ptr<HDA_PulseRecorder> pulseRecorder
 #endif
   );
@@ -108,16 +112,18 @@ private:
    *  to model the circumference (i.e., at which angle in the circle).
    * @see FullWaveformPulseRunnable::computeSubrays
    */
-  void handleSubray(Rotation const &subrayRotation, int const subrayRadiusStep,
-                    NoiseSource<double> &intersectionHandlingNoiseSource,
-                    std::map<double, double> &reflections,
-                    vector<RaySceneIntersection> &intersects,
-                    std::vector<DiscreteSubrayReturn> &discreteSubrayReturns,
+  void handleSubray(Rotation const& subrayRotation,
+                    int const subrayRadiusStep,
+                    NoiseSource<double>& intersectionHandlingNoiseSource,
+                    std::map<double, double>& reflections,
+                    vector<RaySceneIntersection>& intersects,
+                    std::vector<DiscreteSubrayReturn>& discreteSubrayReturns,
                     bool const collectDiscreteSubrayReturns
 #if DATA_ANALYTICS >= 2
                     ,
-                    bool &subrayHit, std::vector<double> &subraySimRecord,
-                    std::vector<std::vector<double>> &calcIntensityRecords
+                    bool& subrayHit,
+                    std::vector<double>& subraySimRecord,
+                    std::vector<std::vector<double>>& calcIntensityRecords
 #endif
   );
   /**
@@ -135,17 +141,18 @@ private:
    * @see FullWaveformPulseRunnable::exportOutput
    */
   void digestIntersections(
-      std::vector<std::vector<double>> &apMatrix,
-      RandomnessGenerator<double> &randGen,
-      RandomnessGenerator<double> &randGen2, glm::dvec3 &beamDir,
-      std::map<double, double> &reflections,
-      vector<RaySceneIntersection> &intersects,
-      std::vector<DiscreteSubrayReturn> const &discreteSubrayReturns
+    std::vector<std::vector<double>>& apMatrix,
+    RandomnessGenerator<double>& randGen,
+    RandomnessGenerator<double>& randGen2,
+    glm::dvec3& beamDir,
+    std::map<double, double>& reflections,
+    vector<RaySceneIntersection>& intersects,
+    std::vector<DiscreteSubrayReturn> const& discreteSubrayReturns
 #if DATA_ANALYTICS >= 2
-      ,
-      std::vector<std::vector<double>> &calcIntensityRecords,
-      std::vector<std::vector<int>> &calcIntensityIndices,
-      std::shared_ptr<HDA_PulseRecorder> pulseRecorder
+    ,
+    std::vector<std::vector<double>>& calcIntensityRecords,
+    std::vector<std::vector<int>>& calcIntensityIndices,
+    std::shared_ptr<HDA_PulseRecorder> pulseRecorder
 #endif
   );
   /**
@@ -154,8 +161,9 @@ private:
    * @param[out] maxHitDist_m Max hit distance will be stored here
    * @see FullWaveformPulseRunnable::digestIntersections
    */
-  void findMaxMinHitDistances(std::map<double, double> &reflections,
-                              double &minHitDist_m, double &maxHitDist_m);
+  void findMaxMinHitDistances(std::map<double, double>& reflections,
+                              double& minHitDist_m,
+                              double& maxHitDist_m);
   /**
    * @brief Initialize full waveform
    * While the vector is not strictly initialized in this function,
@@ -170,20 +178,24 @@ private:
    * @see FullWaveformPulseRunnable::digestIntersections
    */
   bool initializeFullWaveform(double const minHitDist_m,
-                              double const maxHitDist_m, double &minHitTime_ns,
-                              double &maxHitTime_ns, double &nsPerBin,
-                              double &distanceThreshold,
-                              int &peakIntensityIndex, int &numFullwaveBins);
+                              double const maxHitDist_m,
+                              double& minHitTime_ns,
+                              double& maxHitTime_ns,
+                              double& nsPerBin,
+                              double& distanceThreshold,
+                              int& peakIntensityIndex,
+                              int& numFullwaveBins);
   /**
    * @brief Populate a previously initialized full waveform vector
    * @param[out] fullwave Full waveform vector to be populated
    * @see FullWaveformPulseRunnable::digestIntersections
    * @see FullWaveformPulseRunnable::initializeFullWaveform
    */
-  void populateFullWaveform(std::map<double, double> const &reflections,
-                            std::vector<double> &fullwave,
+  void populateFullWaveform(std::map<double, double> const& reflections,
+                            std::vector<double>& fullwave,
                             double const distanceThreshold,
-                            double const minHitTime_ns, double const nsPerBin,
+                            double const minHitTime_ns,
+                            double const nsPerBin,
                             int const peakIntensityIndex);
   /**
    * @brief Digest a previously populated full waveform vector,
@@ -197,18 +209,22 @@ private:
    * @see Measurement
    */
   void digestFullWaveform(
-      std::vector<Measurement> &pointsMeasurement, int &numReturns,
-      std::vector<std::vector<double>> &apMatrix,
-      std::vector<double> const &fullwave,
-      vector<RaySceneIntersection> const &intersects, glm::dvec3 const &beamDir,
-      double const nsPerBin, int const numFullwaveBins,
-      int const peakIntensityIndex, double const minHitTime_ns,
-      std::vector<DiscreteSubrayReturn> const &discreteSubrayReturns
+    std::vector<Measurement>& pointsMeasurement,
+    int& numReturns,
+    std::vector<std::vector<double>>& apMatrix,
+    std::vector<double> const& fullwave,
+    vector<RaySceneIntersection> const& intersects,
+    glm::dvec3 const& beamDir,
+    double const nsPerBin,
+    int const numFullwaveBins,
+    int const peakIntensityIndex,
+    double const minHitTime_ns,
+    std::vector<DiscreteSubrayReturn> const& discreteSubrayReturns
 #if DATA_ANALYTICS >= 2
-      ,
-      std::vector<std::vector<double>> &calcIntensityRecords,
-      std::vector<std::vector<int>> &calcIntensityIndices,
-      std::shared_ptr<HDA_PulseRecorder> pulseRecorder
+    ,
+    std::vector<std::vector<double>>& calcIntensityRecords,
+    std::vector<std::vector<int>>& calcIntensityIndices,
+    std::shared_ptr<HDA_PulseRecorder> pulseRecorder
 #endif
   );
   /**
@@ -223,9 +239,11 @@ private:
    *  hit, i.e., true to skip the current iteration. False to proceed with
    *  the computation of the current iteration.
    */
-  bool handleFullWaveformBin(std::vector<double> const &fullwave,
-                             MarquardtFitter &fit, double &echoWidth,
-                             int const binIndex, int const winSize,
+  bool handleFullWaveformBin(std::vector<double> const& fullwave,
+                             MarquardtFitter& fit,
+                             double& echoWidth,
+                             int const binIndex,
+                             int const winSize,
                              double const nsPerBin);
   /**
    * @brief Export measurements and full waveform data
@@ -233,16 +251,18 @@ private:
    * @param[in] pointsMeasurement Point cloud data to export
    * @see FullWaveformPulseRunnable::digestIntersections
    */
-  void exportOutput(std::vector<double> &fullwave, int const numReturns,
-                    std::vector<Measurement> &pointsMeasurement,
-                    glm::dvec3 const &beamDir, double const minHitTime_ns,
+  void exportOutput(std::vector<double>& fullwave,
+                    int const numReturns,
+                    std::vector<Measurement>& pointsMeasurement,
+                    glm::dvec3 const& beamDir,
+                    double const minHitTime_ns,
                     double const maxHitTime_ns,
-                    RandomnessGenerator<double> &randGen,
-                    RandomnessGenerator<double> &randGen2
+                    RandomnessGenerator<double>& randGen,
+                    RandomnessGenerator<double>& randGen2
 #if DATA_ANALYTICS >= 2
                     ,
-                    std::vector<std::vector<double>> &calcIntensityRecords,
-                    std::vector<std::vector<int>> &calcIntensityIndices,
+                    std::vector<std::vector<double>>& calcIntensityRecords,
+                    std::vector<std::vector<int>>& calcIntensityIndices,
                     std::shared_ptr<HDA_PulseRecorder> pulseRecorder
 #endif
   );
@@ -257,14 +277,17 @@ private:
    * @param v The ray director vector
    * @return Intersection between the scene and given ray
    */
-  virtual std::shared_ptr<RaySceneIntersection>
-  findIntersection(std::vector<double> const &tMinMax, glm::dvec3 const &o,
-                   glm::dvec3 const &v) const;
+  virtual std::shared_ptr<RaySceneIntersection> findIntersection(
+    std::vector<double> const& tMinMax,
+    glm::dvec3 const& o,
+    glm::dvec3 const& v) const;
   /**
    * @brief Detect full waveform peaks
    */
-  bool detectPeak(int const i, int const win_size,
-                  std::vector<double> const &fullwave, double const eps);
+  bool detectPeak(int const i,
+                  int const win_size,
+                  std::vector<double> const& fullwave,
+                  double const eps);
 
   /**
    * @brief Capture full wave
@@ -280,11 +303,15 @@ private:
    * @param rg2 Randomness generator to be used to add noise to the full wave
    *  if requested
    */
-  void captureFullWave(std::vector<double> &fullwave, int const fullwaveIndex,
-                       double const min_time, double const max_time,
-                       glm::dvec3 const &beamOrigin, glm::dvec3 const &beamDir,
-                       double const gpstime, bool const fullWaveNoise,
-                       RandomnessGenerator<double> &rg2);
+  void captureFullWave(std::vector<double>& fullwave,
+                       int const fullwaveIndex,
+                       double const min_time,
+                       double const max_time,
+                       glm::dvec3 const& beamOrigin,
+                       glm::dvec3 const& beamDir,
+                       double const gpstime,
+                       bool const fullWaveNoise,
+                       RandomnessGenerator<double>& rg2);
 
   /**
    * @brief Check whether the ray/subray must be aborted or not depending
@@ -304,7 +331,8 @@ private:
    * @see Scene
    * @see AABB
    */
-  inline bool checkEarlyAbort(std::vector<double> const &tMinMax) {
+  inline bool checkEarlyAbort(std::vector<double> const& tMinMax)
+  {
     return tMinMax.empty() || (tMinMax[0] < 0 && tMinMax[1] <= 0);
   }
 
@@ -316,9 +344,10 @@ public:
    * due to compatibility reasons.
    * @see AbstractPulseRunnable::operator()
    */
-  void operator()() override {
+  void operator()() override
+  {
     throw HeliosException(
-        "FullWaveformPulseRunnable operator()() must not be used");
+      "FullWaveformPulseRunnable operator()() must not be used");
   }
   /**
    * @brief Full waveform pulse runnable functor
@@ -330,10 +359,10 @@ public:
    * intersection handling if necessary
    * @see AbstractPulseRunnable::operator()()
    */
-  void operator()(std::vector<std::vector<double>> &apMatrix,
-                  RandomnessGenerator<double> &randGen,
-                  RandomnessGenerator<double> &randGen2,
-                  NoiseSource<double> &intersectionHandlingNoiseSource
+  void operator()(std::vector<std::vector<double>>& apMatrix,
+                  RandomnessGenerator<double>& randGen,
+                  RandomnessGenerator<double>& randGen2,
+                  NoiseSource<double>& intersectionHandlingNoiseSource
 #if DATA_ANALYTICS >= 2
                   ,
                   std::shared_ptr<HDA_PulseRecorder> pulseRecorder

--- a/src/test/SnapToSurfaceTest.h
+++ b/src/test/SnapToSurfaceTest.h
@@ -81,7 +81,8 @@ protected:
     }
   };
 
-  bool testSnapToSurfaceSelectsClosestContributingSurface();
+  bool testSnapToSurfaceSelectsInnermostContributingSurface();
+  bool testSnapToSurfaceBreaksSameRingTiesByShortestDistance();
   bool testSnapToSurfaceFallsBackWhenBeamSampleQualityIsOne();
 
   static glm::dvec3 normalize(glm::dvec3 const& v)
@@ -110,7 +111,9 @@ protected:
 bool
 SnapToSurfaceTest::run()
 {
-  if (!testSnapToSurfaceSelectsClosestContributingSurface())
+  if (!testSnapToSurfaceSelectsInnermostContributingSurface())
+    return false;
+  if (!testSnapToSurfaceBreaksSameRingTiesByShortestDistance())
     return false;
   if (!testSnapToSurfaceFallsBackWhenBeamSampleQualityIsOne())
     return false;
@@ -118,38 +121,38 @@ SnapToSurfaceTest::run()
 }
 
 bool
-SnapToSurfaceTest::testSnapToSurfaceSelectsClosestContributingSurface()
+SnapToSurfaceTest::testSnapToSurfaceSelectsInnermostContributingSurface()
 {
   RunnableFixture fixture(true, 3);
 
-  auto fallbackPart = std::make_shared<ScenePart>();
-  fallbackPart->mId = "fallback_candidate";
-  auto fallbackMaterial = std::make_shared<Material>();
-  fallbackMaterial->classification = 3;
-  Voxel fallbackVoxel(2.0, 9.95, 0.0, 0.5);
-  fallbackVoxel.part = fallbackPart;
-  fallbackVoxel.material = fallbackMaterial;
+  auto innerPart = std::make_shared<ScenePart>();
+  innerPart->mId = "inner_ring_candidate";
+  auto innerMaterial = std::make_shared<Material>();
+  innerMaterial->classification = 3;
+  Voxel innerVoxel(0.8, 10.3, 0.0, 0.5);
+  innerVoxel.part = innerPart;
+  innerVoxel.material = innerMaterial;
 
-  auto snapPart = std::make_shared<ScenePart>();
-  snapPart->mId = "snap_candidate";
-  auto snapMaterial = std::make_shared<Material>();
-  snapMaterial->classification = 7;
-  Voxel snapVoxel(0.1, 10.3, 0.0, 0.5);
-  snapVoxel.part = snapPart;
-  snapVoxel.material = snapMaterial;
+  auto outerPart = std::make_shared<ScenePart>();
+  outerPart->mId = "outer_ring_candidate";
+  auto outerMaterial = std::make_shared<Material>();
+  outerMaterial->classification = 7;
+  Voxel outerVoxel(0.1, 10.1, 0.0, 0.5);
+  outerVoxel.part = outerPart;
+  outerVoxel.material = outerMaterial;
 
   std::vector<RaySceneIntersection> intersects(2);
-  intersects[0].prim = &fallbackVoxel;
-  intersects[0].point = glm::dvec3(2.0, 9.95, 0.0);
-  intersects[1].prim = &snapVoxel;
-  intersects[1].point = glm::dvec3(0.1, 10.3, 0.0);
+  intersects[0].prim = &innerVoxel;
+  intersects[0].point = glm::dvec3(0.8, 10.3, 0.0);
+  intersects[1].prim = &outerVoxel;
+  intersects[1].point = glm::dvec3(0.1, 10.1, 0.0);
 
   std::vector<DiscreteSubrayReturn> discreteSubrayReturns(2);
-  discreteSubrayReturns[0].distance = glm::length(intersects[0].point);
   discreteSubrayReturns[0].intensity = 1.0;
+  discreteSubrayReturns[0].subrayRadiusStep = 1;
   discreteSubrayReturns[0].intersectsIndex = 0;
-  discreteSubrayReturns[1].distance = glm::length(intersects[1].point);
   discreteSubrayReturns[1].intensity = 1.0;
+  discreteSubrayReturns[1].subrayRadiusStep = 2;
   discreteSubrayReturns[1].intersectsIndex = 1;
 
   std::vector<Measurement> pointsMeasurement;
@@ -172,13 +175,77 @@ SnapToSurfaceTest::testSnapToSurfaceSelectsClosestContributingSurface()
   if (numReturns != 1 || pointsMeasurement.size() != 1)
     return false;
 
-  glm::dvec3 const expectedDirection = normalize(intersects[1].point);
-  double const expectedDistance = glm::length(intersects[1].point);
+  glm::dvec3 const expectedDirection = normalize(intersects[0].point);
+  double const expectedDistance = glm::length(intersects[0].point);
   return validateMeasurement(pointsMeasurement[0],
                              expectedDirection,
                              expectedDistance,
-                             "snap_candidate",
-                             7);
+                             "inner_ring_candidate",
+                             3);
+}
+
+bool
+SnapToSurfaceTest::testSnapToSurfaceBreaksSameRingTiesByShortestDistance()
+{
+  RunnableFixture fixture(true, 3);
+
+  auto nearPart = std::make_shared<ScenePart>();
+  nearPart->mId = "near_candidate";
+  auto nearMaterial = std::make_shared<Material>();
+  nearMaterial->classification = 5;
+  Voxel nearVoxel(0.4, 10.1, 0.0, 0.5);
+  nearVoxel.part = nearPart;
+  nearVoxel.material = nearMaterial;
+
+  auto farPart = std::make_shared<ScenePart>();
+  farPart->mId = "far_candidate";
+  auto farMaterial = std::make_shared<Material>();
+  farMaterial->classification = 9;
+  Voxel farVoxel(0.1, 10.3, 0.0, 0.5);
+  farVoxel.part = farPart;
+  farVoxel.material = farMaterial;
+
+  std::vector<RaySceneIntersection> intersects(2);
+  intersects[0].prim = &nearVoxel;
+  intersects[0].point = glm::dvec3(0.4, 10.1, 0.0);
+  intersects[1].prim = &farVoxel;
+  intersects[1].point = glm::dvec3(0.1, 10.3, 0.0);
+
+  std::vector<DiscreteSubrayReturn> discreteSubrayReturns(2);
+  discreteSubrayReturns[0].intensity = 1.0;
+  discreteSubrayReturns[0].subrayRadiusStep = 1;
+  discreteSubrayReturns[0].intersectsIndex = 0;
+  discreteSubrayReturns[1].intensity = 1.0;
+  discreteSubrayReturns[1].subrayRadiusStep = 1;
+  discreteSubrayReturns[1].intersectsIndex = 1;
+
+  std::vector<Measurement> pointsMeasurement;
+  int numReturns = 0;
+  std::vector<std::vector<double>> apMatrix;
+  std::vector<double> fullwave({ 10.0, 0.0, 0.0 });
+
+  fixture.runnable->digestFullWaveform(pointsMeasurement,
+                                       numReturns,
+                                       apMatrix,
+                                       fullwave,
+                                       intersects,
+                                       glm::dvec3(0.0, 1.0, 0.0),
+                                       1.0,
+                                       3,
+                                       0,
+                                       33.5,
+                                       discreteSubrayReturns);
+
+  if (numReturns != 1 || pointsMeasurement.size() != 1)
+    return false;
+
+  glm::dvec3 const expectedDirection = normalize(intersects[0].point);
+  double const expectedDistance = glm::length(intersects[0].point);
+  return validateMeasurement(pointsMeasurement[0],
+                             expectedDirection,
+                             expectedDistance,
+                             "near_candidate",
+                             5);
 }
 
 bool
@@ -209,11 +276,11 @@ SnapToSurfaceTest::testSnapToSurfaceFallsBackWhenBeamSampleQualityIsOne()
   intersects[1].point = glm::dvec3(0.1, 10.3, 0.0);
 
   std::vector<DiscreteSubrayReturn> discreteSubrayReturns(2);
-  discreteSubrayReturns[0].distance = glm::length(intersects[0].point);
   discreteSubrayReturns[0].intensity = 1.0;
+  discreteSubrayReturns[0].subrayRadiusStep = 0;
   discreteSubrayReturns[0].intersectsIndex = 0;
-  discreteSubrayReturns[1].distance = glm::length(intersects[1].point);
   discreteSubrayReturns[1].intensity = 1.0;
+  discreteSubrayReturns[1].subrayRadiusStep = 1;
   discreteSubrayReturns[1].intersectsIndex = 1;
 
   std::vector<Measurement> pointsMeasurement;

--- a/src/test/SnapToSurfaceTest.h
+++ b/src/test/SnapToSurfaceTest.h
@@ -13,16 +13,21 @@ namespace HeliosTests {
 /**
  * @brief Test for full-waveform snapToSurface behavior
  */
-class SnapToSurfaceTest : public BaseTest {
+class SnapToSurfaceTest : public BaseTest
+{
 public:
   double const eps = 1e-6;
 
-  SnapToSurfaceTest() : BaseTest("Snap to surface test") {}
+  SnapToSurfaceTest()
+    : BaseTest("Snap to surface test")
+  {
+  }
 
   bool run() override;
 
 protected:
-  struct RunnableFixture {
+  struct RunnableFixture
+  {
     std::shared_ptr<Scanner> scanner;
     std::shared_ptr<LinearPathPlatform> platform;
     std::shared_ptr<Scene> scene;
@@ -33,17 +38,32 @@ protected:
     std::unique_ptr<FullWaveformPulseRunnable> runnable;
 
     RunnableFixture(bool const snapToSurface, int const beamSampleQuality)
-        : scanner(std::make_shared<SingleScanner>(
-              0.0003, glm::dvec3(0, 0, 0), Rotation(), std::list<int>({100000}),
-              5.0, "scanDev0", 4.0, 1.0, 0.99, 0.15, 1.0, 1064, nullptr, false,
-              false, false, false, false)),
-          platform(std::make_shared<LinearPathPlatform>()),
-          scene(std::make_shared<Scene>()),
-          detector(
-              std::make_shared<FullWaveformPulseDetector>(scanner, 0.0, 0.01)),
-          allMeasurements(std::make_shared<std::vector<Measurement>>()),
-          allMeasurementsMutex(std::make_shared<std::mutex>()),
-          pulse(glm::dvec3(0, 0, 0), Rotation(), 0.0, 0u, 0, 0u) {
+      : scanner(std::make_shared<SingleScanner>(0.0003,
+                                                glm::dvec3(0, 0, 0),
+                                                Rotation(),
+                                                std::list<int>({ 100000 }),
+                                                5.0,
+                                                "scanDev0",
+                                                4.0,
+                                                1.0,
+                                                0.99,
+                                                0.15,
+                                                1.0,
+                                                1064,
+                                                nullptr,
+                                                false,
+                                                false,
+                                                false,
+                                                false,
+                                                false))
+      , platform(std::make_shared<LinearPathPlatform>())
+      , scene(std::make_shared<Scene>())
+      , detector(
+          std::make_shared<FullWaveformPulseDetector>(scanner, 0.0, 0.01))
+      , allMeasurements(std::make_shared<std::vector<Measurement>>())
+      , allMeasurementsMutex(std::make_shared<std::mutex>())
+      , pulse(glm::dvec3(0, 0, 0), Rotation(), 0.0, 0u, 0, 0u)
+    {
       FWFSettings fwfSettings;
       fwfSettings.snapToSurface = snapToSurface;
       fwfSettings.beamSampleQuality = beamSampleQuality;
@@ -52,7 +72,7 @@ protected:
       scanner->setDetector(detector);
       scanner->setReceivedEnergyMin(0.1);
       scanner->setMaxNOR(1);
-      scanner->setTimeWave(std::vector<double>({1.0}));
+      scanner->setTimeWave(std::vector<double>({ 1.0 }));
       scanner->platform = platform;
       scanner->allMeasurements = allMeasurements;
       scanner->allMeasurementsMutex = allMeasurementsMutex;
@@ -64,15 +84,17 @@ protected:
   bool testSnapToSurfaceSelectsClosestContributingSurface();
   bool testSnapToSurfaceFallsBackWhenBeamSampleQualityIsOne();
 
-  static glm::dvec3 normalize(glm::dvec3 const &v) {
+  static glm::dvec3 normalize(glm::dvec3 const& v)
+  {
     return v / glm::length(v);
   }
 
-  bool validateMeasurement(Measurement const &measurement,
-                           glm::dvec3 const &expectedDirection,
+  bool validateMeasurement(Measurement const& measurement,
+                           glm::dvec3 const& expectedDirection,
                            double const expectedDistance,
-                           std::string const &expectedHitObjectId,
-                           int const expectedClassification) {
+                           std::string const& expectedHitObjectId,
+                           int const expectedClassification)
+  {
     if (measurement.hitObjectId != expectedHitObjectId)
       return false;
     if (measurement.classification != expectedClassification)
@@ -85,7 +107,9 @@ protected:
   }
 };
 
-bool SnapToSurfaceTest::run() {
+bool
+SnapToSurfaceTest::run()
+{
   if (!testSnapToSurfaceSelectsClosestContributingSurface())
     return false;
   if (!testSnapToSurfaceFallsBackWhenBeamSampleQualityIsOne())
@@ -93,7 +117,9 @@ bool SnapToSurfaceTest::run() {
   return true;
 }
 
-bool SnapToSurfaceTest::testSnapToSurfaceSelectsClosestContributingSurface() {
+bool
+SnapToSurfaceTest::testSnapToSurfaceSelectsClosestContributingSurface()
+{
   RunnableFixture fixture(true, 3);
 
   auto fallbackPart = std::make_shared<ScenePart>();
@@ -129,22 +155,35 @@ bool SnapToSurfaceTest::testSnapToSurfaceSelectsClosestContributingSurface() {
   std::vector<Measurement> pointsMeasurement;
   int numReturns = 0;
   std::vector<std::vector<double>> apMatrix;
-  std::vector<double> fullwave({10.0, 0.0, 0.0});
+  std::vector<double> fullwave({ 10.0, 0.0, 0.0 });
 
-  fixture.runnable->digestFullWaveform(
-      pointsMeasurement, numReturns, apMatrix, fullwave, intersects,
-      glm::dvec3(0.0, 1.0, 0.0), 1.0, 3, 0, 33.5, discreteSubrayReturns);
+  fixture.runnable->digestFullWaveform(pointsMeasurement,
+                                       numReturns,
+                                       apMatrix,
+                                       fullwave,
+                                       intersects,
+                                       glm::dvec3(0.0, 1.0, 0.0),
+                                       1.0,
+                                       3,
+                                       0,
+                                       33.5,
+                                       discreteSubrayReturns);
 
   if (numReturns != 1 || pointsMeasurement.size() != 1)
     return false;
 
   glm::dvec3 const expectedDirection = normalize(intersects[1].point);
   double const expectedDistance = glm::length(intersects[1].point);
-  return validateMeasurement(pointsMeasurement[0], expectedDirection,
-                             expectedDistance, "snap_candidate", 7);
+  return validateMeasurement(pointsMeasurement[0],
+                             expectedDirection,
+                             expectedDistance,
+                             "snap_candidate",
+                             7);
 }
 
-bool SnapToSurfaceTest::testSnapToSurfaceFallsBackWhenBeamSampleQualityIsOne() {
+bool
+SnapToSurfaceTest::testSnapToSurfaceFallsBackWhenBeamSampleQualityIsOne()
+{
   RunnableFixture fixture(true, 1);
 
   auto fallbackPart = std::make_shared<ScenePart>();
@@ -180,19 +219,30 @@ bool SnapToSurfaceTest::testSnapToSurfaceFallsBackWhenBeamSampleQualityIsOne() {
   std::vector<Measurement> pointsMeasurement;
   int numReturns = 0;
   std::vector<std::vector<double>> apMatrix;
-  std::vector<double> fullwave({10.0, 0.0, 0.0});
+  std::vector<double> fullwave({ 10.0, 0.0, 0.0 });
 
-  fixture.runnable->digestFullWaveform(
-      pointsMeasurement, numReturns, apMatrix, fullwave, intersects,
-      glm::dvec3(0.0, 1.0, 0.0), 1.0, 3, 0, 33.5, discreteSubrayReturns);
+  fixture.runnable->digestFullWaveform(pointsMeasurement,
+                                       numReturns,
+                                       apMatrix,
+                                       fullwave,
+                                       intersects,
+                                       glm::dvec3(0.0, 1.0, 0.0),
+                                       1.0,
+                                       3,
+                                       0,
+                                       33.5,
+                                       discreteSubrayReturns);
 
   if (numReturns != 1 || pointsMeasurement.size() != 1)
     return false;
 
   glm::dvec3 const expectedDirection = glm::dvec3(0.0, 1.0, 0.0);
   double const expectedDistance = SPEEDofLIGHT_mPerNanosec * 33.5;
-  return validateMeasurement(pointsMeasurement[0], expectedDirection,
-                             expectedDistance, "fallback_candidate", 3);
+  return validateMeasurement(pointsMeasurement[0],
+                             expectedDirection,
+                             expectedDistance,
+                             "fallback_candidate",
+                             3);
 }
 
 } // namespace HeliosTests

--- a/src/test/SnapToSurfaceTest.h
+++ b/src/test/SnapToSurfaceTest.h
@@ -1,0 +1,251 @@
+#pragma once
+
+#include <BaseTest.h>
+#include <platform/LinearPathPlatform.h>
+#include <scene/Material.h>
+#include <scene/Scene.h>
+#include <scene/primitives/Voxel.h>
+#include <scanner/SingleScanner.h>
+
+#define private public
+#include <scanner/detector/FullWaveformPulseRunnable.h>
+#undef private
+
+namespace HeliosTests {
+
+/**
+ * @brief Test for full-waveform snapToSurface behavior
+ */
+class SnapToSurfaceTest : public BaseTest
+{
+public:
+  double const eps = 1e-6;
+
+  SnapToSurfaceTest()
+    : BaseTest("Snap to surface test")
+  {
+  }
+
+  bool run() override;
+
+protected:
+  struct RunnableFixture
+  {
+    std::shared_ptr<Scanner> scanner;
+    std::shared_ptr<LinearPathPlatform> platform;
+    std::shared_ptr<Scene> scene;
+    std::shared_ptr<FullWaveformPulseDetector> detector;
+    std::shared_ptr<std::vector<Measurement>> allMeasurements;
+    std::shared_ptr<std::mutex> allMeasurementsMutex;
+    SimulatedPulse pulse;
+    std::unique_ptr<FullWaveformPulseRunnable> runnable;
+
+    RunnableFixture(bool const snapToSurface, int const beamSampleQuality)
+      : scanner(std::make_shared<SingleScanner>(0.0003,
+                                                glm::dvec3(0, 0, 0),
+                                                Rotation(),
+                                                std::list<int>({ 100000 }),
+                                                5.0,
+                                                "scanDev0",
+                                                4.0,
+                                                1.0,
+                                                0.99,
+                                                0.15,
+                                                1.0,
+                                                1064,
+                                                nullptr,
+                                                false,
+                                                false,
+                                                false,
+                                                false,
+                                                false))
+      , platform(std::make_shared<LinearPathPlatform>())
+      , scene(std::make_shared<Scene>())
+      , detector(
+          std::make_shared<FullWaveformPulseDetector>(scanner, 0.0, 0.01))
+      , allMeasurements(std::make_shared<std::vector<Measurement>>())
+      , allMeasurementsMutex(std::make_shared<std::mutex>())
+      , pulse(glm::dvec3(0, 0, 0), Rotation(), 0.0, 0u, 0, 0u)
+    {
+      FWFSettings fwfSettings;
+      fwfSettings.snapToSurface = snapToSurface;
+      fwfSettings.beamSampleQuality = beamSampleQuality;
+      fwfSettings.winSize_ns = 1.0;
+      scanner->setFWFSettings(fwfSettings);
+      scanner->setDetector(detector);
+      scanner->setReceivedEnergyMin(0.1);
+      scanner->setMaxNOR(1);
+      scanner->setTimeWave(std::vector<double>({ 1.0 }));
+      scanner->platform = platform;
+      scanner->allMeasurements = allMeasurements;
+      scanner->allMeasurementsMutex = allMeasurementsMutex;
+      platform->scene = scene;
+      runnable = std::make_unique<FullWaveformPulseRunnable>(scanner, pulse);
+    }
+  };
+
+  bool testSnapToSurfaceSelectsClosestContributingSurface();
+  bool testSnapToSurfaceFallsBackWhenBeamSampleQualityIsOne();
+
+  static glm::dvec3 normalize(glm::dvec3 const& v)
+  {
+    return v / glm::length(v);
+  }
+
+  bool validateMeasurement(Measurement const& measurement,
+                           glm::dvec3 const& expectedDirection,
+                           double const expectedDistance,
+                           std::string const& expectedHitObjectId,
+                           int const expectedClassification)
+  {
+    if (measurement.hitObjectId != expectedHitObjectId)
+      return false;
+    if (measurement.classification != expectedClassification)
+      return false;
+    if (std::fabs(measurement.distance - expectedDistance) > eps)
+      return false;
+    if (glm::length(measurement.beamDirection - expectedDirection) > eps)
+      return false;
+    return true;
+  }
+};
+
+bool
+SnapToSurfaceTest::run()
+{
+  if (!testSnapToSurfaceSelectsClosestContributingSurface())
+    return false;
+  if (!testSnapToSurfaceFallsBackWhenBeamSampleQualityIsOne())
+    return false;
+  return true;
+}
+
+bool
+SnapToSurfaceTest::testSnapToSurfaceSelectsClosestContributingSurface()
+{
+  RunnableFixture fixture(true, 3);
+
+  auto fallbackPart = std::make_shared<ScenePart>();
+  fallbackPart->mId = "fallback_candidate";
+  auto fallbackMaterial = std::make_shared<Material>();
+  fallbackMaterial->classification = 3;
+  Voxel fallbackVoxel(2.0, 9.95, 0.0, 0.5);
+  fallbackVoxel.part = fallbackPart;
+  fallbackVoxel.material = fallbackMaterial;
+
+  auto snapPart = std::make_shared<ScenePart>();
+  snapPart->mId = "snap_candidate";
+  auto snapMaterial = std::make_shared<Material>();
+  snapMaterial->classification = 7;
+  Voxel snapVoxel(0.1, 10.3, 0.0, 0.5);
+  snapVoxel.part = snapPart;
+  snapVoxel.material = snapMaterial;
+
+  std::vector<RaySceneIntersection> intersects(2);
+  intersects[0].prim = &fallbackVoxel;
+  intersects[0].point = glm::dvec3(2.0, 9.95, 0.0);
+  intersects[1].prim = &snapVoxel;
+  intersects[1].point = glm::dvec3(0.1, 10.3, 0.0);
+
+  std::vector<DiscreteSubrayReturn> discreteSubrayReturns(2);
+  discreteSubrayReturns[0].distance = glm::length(intersects[0].point);
+  discreteSubrayReturns[0].intensity = 1.0;
+  discreteSubrayReturns[0].intersectsIndex = 0;
+  discreteSubrayReturns[1].distance = glm::length(intersects[1].point);
+  discreteSubrayReturns[1].intensity = 1.0;
+  discreteSubrayReturns[1].intersectsIndex = 1;
+
+  std::vector<Measurement> pointsMeasurement;
+  int numReturns = 0;
+  std::vector<std::vector<double>> apMatrix;
+  std::vector<double> fullwave({ 10.0, 0.0, 0.0 });
+
+  fixture.runnable->digestFullWaveform(pointsMeasurement,
+                                       numReturns,
+                                       apMatrix,
+                                       fullwave,
+                                       intersects,
+                                       glm::dvec3(0.0, 1.0, 0.0),
+                                       1.0,
+                                       3,
+                                       0,
+                                       33.5,
+                                       discreteSubrayReturns);
+
+  if (numReturns != 1 || pointsMeasurement.size() != 1)
+    return false;
+
+  glm::dvec3 const expectedDirection = normalize(intersects[1].point);
+  double const expectedDistance = glm::length(intersects[1].point);
+  return validateMeasurement(pointsMeasurement[0],
+                             expectedDirection,
+                             expectedDistance,
+                             "snap_candidate",
+                             7);
+}
+
+bool
+SnapToSurfaceTest::testSnapToSurfaceFallsBackWhenBeamSampleQualityIsOne()
+{
+  RunnableFixture fixture(true, 1);
+
+  auto fallbackPart = std::make_shared<ScenePart>();
+  fallbackPart->mId = "fallback_candidate";
+  auto fallbackMaterial = std::make_shared<Material>();
+  fallbackMaterial->classification = 3;
+  Voxel fallbackVoxel(2.0, 9.95, 0.0, 0.5);
+  fallbackVoxel.part = fallbackPart;
+  fallbackVoxel.material = fallbackMaterial;
+
+  auto snapPart = std::make_shared<ScenePart>();
+  snapPart->mId = "snap_candidate";
+  auto snapMaterial = std::make_shared<Material>();
+  snapMaterial->classification = 7;
+  Voxel snapVoxel(0.1, 10.3, 0.0, 0.5);
+  snapVoxel.part = snapPart;
+  snapVoxel.material = snapMaterial;
+
+  std::vector<RaySceneIntersection> intersects(2);
+  intersects[0].prim = &fallbackVoxel;
+  intersects[0].point = glm::dvec3(2.0, 9.95, 0.0);
+  intersects[1].prim = &snapVoxel;
+  intersects[1].point = glm::dvec3(0.1, 10.3, 0.0);
+
+  std::vector<DiscreteSubrayReturn> discreteSubrayReturns(2);
+  discreteSubrayReturns[0].distance = glm::length(intersects[0].point);
+  discreteSubrayReturns[0].intensity = 1.0;
+  discreteSubrayReturns[0].intersectsIndex = 0;
+  discreteSubrayReturns[1].distance = glm::length(intersects[1].point);
+  discreteSubrayReturns[1].intensity = 1.0;
+  discreteSubrayReturns[1].intersectsIndex = 1;
+
+  std::vector<Measurement> pointsMeasurement;
+  int numReturns = 0;
+  std::vector<std::vector<double>> apMatrix;
+  std::vector<double> fullwave({ 10.0, 0.0, 0.0 });
+
+  fixture.runnable->digestFullWaveform(pointsMeasurement,
+                                       numReturns,
+                                       apMatrix,
+                                       fullwave,
+                                       intersects,
+                                       glm::dvec3(0.0, 1.0, 0.0),
+                                       1.0,
+                                       3,
+                                       0,
+                                       33.5,
+                                       discreteSubrayReturns);
+
+  if (numReturns != 1 || pointsMeasurement.size() != 1)
+    return false;
+
+  glm::dvec3 const expectedDirection = glm::dvec3(0.0, 1.0, 0.0);
+  double const expectedDistance = SPEEDofLIGHT_mPerNanosec * 33.5;
+  return validateMeasurement(pointsMeasurement[0],
+                             expectedDirection,
+                             expectedDistance,
+                             "fallback_candidate",
+                             3);
+}
+
+}

--- a/src/test/SnapToSurfaceTest.h
+++ b/src/test/SnapToSurfaceTest.h
@@ -2,35 +2,27 @@
 
 #include <BaseTest.h>
 #include <platform/LinearPathPlatform.h>
+#include <scanner/SingleScanner.h>
+#include <scanner/detector/FullWaveformPulseRunnable.h>
 #include <scene/Material.h>
 #include <scene/Scene.h>
 #include <scene/primitives/Voxel.h>
-#include <scanner/SingleScanner.h>
-
-#define private public
-#include <scanner/detector/FullWaveformPulseRunnable.h>
-#undef private
 
 namespace HeliosTests {
 
 /**
  * @brief Test for full-waveform snapToSurface behavior
  */
-class SnapToSurfaceTest : public BaseTest
-{
+class SnapToSurfaceTest : public BaseTest {
 public:
   double const eps = 1e-6;
 
-  SnapToSurfaceTest()
-    : BaseTest("Snap to surface test")
-  {
-  }
+  SnapToSurfaceTest() : BaseTest("Snap to surface test") {}
 
   bool run() override;
 
 protected:
-  struct RunnableFixture
-  {
+  struct RunnableFixture {
     std::shared_ptr<Scanner> scanner;
     std::shared_ptr<LinearPathPlatform> platform;
     std::shared_ptr<Scene> scene;
@@ -41,32 +33,17 @@ protected:
     std::unique_ptr<FullWaveformPulseRunnable> runnable;
 
     RunnableFixture(bool const snapToSurface, int const beamSampleQuality)
-      : scanner(std::make_shared<SingleScanner>(0.0003,
-                                                glm::dvec3(0, 0, 0),
-                                                Rotation(),
-                                                std::list<int>({ 100000 }),
-                                                5.0,
-                                                "scanDev0",
-                                                4.0,
-                                                1.0,
-                                                0.99,
-                                                0.15,
-                                                1.0,
-                                                1064,
-                                                nullptr,
-                                                false,
-                                                false,
-                                                false,
-                                                false,
-                                                false))
-      , platform(std::make_shared<LinearPathPlatform>())
-      , scene(std::make_shared<Scene>())
-      , detector(
-          std::make_shared<FullWaveformPulseDetector>(scanner, 0.0, 0.01))
-      , allMeasurements(std::make_shared<std::vector<Measurement>>())
-      , allMeasurementsMutex(std::make_shared<std::mutex>())
-      , pulse(glm::dvec3(0, 0, 0), Rotation(), 0.0, 0u, 0, 0u)
-    {
+        : scanner(std::make_shared<SingleScanner>(
+              0.0003, glm::dvec3(0, 0, 0), Rotation(), std::list<int>({100000}),
+              5.0, "scanDev0", 4.0, 1.0, 0.99, 0.15, 1.0, 1064, nullptr, false,
+              false, false, false, false)),
+          platform(std::make_shared<LinearPathPlatform>()),
+          scene(std::make_shared<Scene>()),
+          detector(
+              std::make_shared<FullWaveformPulseDetector>(scanner, 0.0, 0.01)),
+          allMeasurements(std::make_shared<std::vector<Measurement>>()),
+          allMeasurementsMutex(std::make_shared<std::mutex>()),
+          pulse(glm::dvec3(0, 0, 0), Rotation(), 0.0, 0u, 0, 0u) {
       FWFSettings fwfSettings;
       fwfSettings.snapToSurface = snapToSurface;
       fwfSettings.beamSampleQuality = beamSampleQuality;
@@ -75,7 +52,7 @@ protected:
       scanner->setDetector(detector);
       scanner->setReceivedEnergyMin(0.1);
       scanner->setMaxNOR(1);
-      scanner->setTimeWave(std::vector<double>({ 1.0 }));
+      scanner->setTimeWave(std::vector<double>({1.0}));
       scanner->platform = platform;
       scanner->allMeasurements = allMeasurements;
       scanner->allMeasurementsMutex = allMeasurementsMutex;
@@ -87,17 +64,15 @@ protected:
   bool testSnapToSurfaceSelectsClosestContributingSurface();
   bool testSnapToSurfaceFallsBackWhenBeamSampleQualityIsOne();
 
-  static glm::dvec3 normalize(glm::dvec3 const& v)
-  {
+  static glm::dvec3 normalize(glm::dvec3 const &v) {
     return v / glm::length(v);
   }
 
-  bool validateMeasurement(Measurement const& measurement,
-                           glm::dvec3 const& expectedDirection,
+  bool validateMeasurement(Measurement const &measurement,
+                           glm::dvec3 const &expectedDirection,
                            double const expectedDistance,
-                           std::string const& expectedHitObjectId,
-                           int const expectedClassification)
-  {
+                           std::string const &expectedHitObjectId,
+                           int const expectedClassification) {
     if (measurement.hitObjectId != expectedHitObjectId)
       return false;
     if (measurement.classification != expectedClassification)
@@ -110,9 +85,7 @@ protected:
   }
 };
 
-bool
-SnapToSurfaceTest::run()
-{
+bool SnapToSurfaceTest::run() {
   if (!testSnapToSurfaceSelectsClosestContributingSurface())
     return false;
   if (!testSnapToSurfaceFallsBackWhenBeamSampleQualityIsOne())
@@ -120,9 +93,7 @@ SnapToSurfaceTest::run()
   return true;
 }
 
-bool
-SnapToSurfaceTest::testSnapToSurfaceSelectsClosestContributingSurface()
-{
+bool SnapToSurfaceTest::testSnapToSurfaceSelectsClosestContributingSurface() {
   RunnableFixture fixture(true, 3);
 
   auto fallbackPart = std::make_shared<ScenePart>();
@@ -158,35 +129,22 @@ SnapToSurfaceTest::testSnapToSurfaceSelectsClosestContributingSurface()
   std::vector<Measurement> pointsMeasurement;
   int numReturns = 0;
   std::vector<std::vector<double>> apMatrix;
-  std::vector<double> fullwave({ 10.0, 0.0, 0.0 });
+  std::vector<double> fullwave({10.0, 0.0, 0.0});
 
-  fixture.runnable->digestFullWaveform(pointsMeasurement,
-                                       numReturns,
-                                       apMatrix,
-                                       fullwave,
-                                       intersects,
-                                       glm::dvec3(0.0, 1.0, 0.0),
-                                       1.0,
-                                       3,
-                                       0,
-                                       33.5,
-                                       discreteSubrayReturns);
+  fixture.runnable->digestFullWaveform(
+      pointsMeasurement, numReturns, apMatrix, fullwave, intersects,
+      glm::dvec3(0.0, 1.0, 0.0), 1.0, 3, 0, 33.5, discreteSubrayReturns);
 
   if (numReturns != 1 || pointsMeasurement.size() != 1)
     return false;
 
   glm::dvec3 const expectedDirection = normalize(intersects[1].point);
   double const expectedDistance = glm::length(intersects[1].point);
-  return validateMeasurement(pointsMeasurement[0],
-                             expectedDirection,
-                             expectedDistance,
-                             "snap_candidate",
-                             7);
+  return validateMeasurement(pointsMeasurement[0], expectedDirection,
+                             expectedDistance, "snap_candidate", 7);
 }
 
-bool
-SnapToSurfaceTest::testSnapToSurfaceFallsBackWhenBeamSampleQualityIsOne()
-{
+bool SnapToSurfaceTest::testSnapToSurfaceFallsBackWhenBeamSampleQualityIsOne() {
   RunnableFixture fixture(true, 1);
 
   auto fallbackPart = std::make_shared<ScenePart>();
@@ -222,30 +180,19 @@ SnapToSurfaceTest::testSnapToSurfaceFallsBackWhenBeamSampleQualityIsOne()
   std::vector<Measurement> pointsMeasurement;
   int numReturns = 0;
   std::vector<std::vector<double>> apMatrix;
-  std::vector<double> fullwave({ 10.0, 0.0, 0.0 });
+  std::vector<double> fullwave({10.0, 0.0, 0.0});
 
-  fixture.runnable->digestFullWaveform(pointsMeasurement,
-                                       numReturns,
-                                       apMatrix,
-                                       fullwave,
-                                       intersects,
-                                       glm::dvec3(0.0, 1.0, 0.0),
-                                       1.0,
-                                       3,
-                                       0,
-                                       33.5,
-                                       discreteSubrayReturns);
+  fixture.runnable->digestFullWaveform(
+      pointsMeasurement, numReturns, apMatrix, fullwave, intersects,
+      glm::dvec3(0.0, 1.0, 0.0), 1.0, 3, 0, 33.5, discreteSubrayReturns);
 
   if (numReturns != 1 || pointsMeasurement.size() != 1)
     return false;
 
   glm::dvec3 const expectedDirection = glm::dvec3(0.0, 1.0, 0.0);
   double const expectedDistance = SPEEDofLIGHT_mPerNanosec * 33.5;
-  return validateMeasurement(pointsMeasurement[0],
-                             expectedDirection,
-                             expectedDistance,
-                             "fallback_candidate",
-                             3);
+  return validateMeasurement(pointsMeasurement[0], expectedDirection,
+                             expectedDistance, "fallback_candidate", 3);
 }
 
-}
+} // namespace HeliosTests

--- a/src/test/Tests.cpp
+++ b/src/test/Tests.cpp
@@ -35,24 +35,27 @@ using namespace HeliosTests;
  * @param testDir Path to directory containing test data
  * @return True if preconditions are satisfied, false otherwise
  */
-bool validateTestsPrecondition(std::string const &testDir);
+bool
+validateTestsPrecondition(std::string const& testDir);
 
-void doTests(std::string const &testDir) {
+void
+doTests(std::string const& testDir)
+{
   // Validate current working directory
   if (!validateTestsPrecondition(testDir)) {
     std::cout
-        << "WARNING! You might not be inside helios root directory.\n\t"
-           "This might cause tests to fail.\n"
-           "Please, change to helios root directory.\n"
-           "Alternatively, specify path to directory containing required test "
-           "files with:\n\t --testDir <path>\n\n"
-           "If this warning persists then probably test data "
-           "files cannot be located.\n"
-           "Get sure files can be located and accessed in your system.\n"
-           "If the problem persists, please report it\n\n"
-           "Current test files directory is: \""
-        << testDir << "\"\n"
-        << std::endl;
+      << "WARNING! You might not be inside helios root directory.\n\t"
+         "This might cause tests to fail.\n"
+         "Please, change to helios root directory.\n"
+         "Alternatively, specify path to directory containing required test "
+         "files with:\n\t --testDir <path>\n\n"
+         "If this warning persists then probably test data "
+         "files cannot be located.\n"
+         "Get sure files can be located and accessed in your system.\n"
+         "If the problem persists, please report it\n\n"
+         "Current test files directory is: \""
+      << testDir << "\"\n"
+      << std::endl;
   }
 
   // ***  T E S T S  *** //
@@ -122,11 +125,13 @@ void doTests(std::string const &testDir) {
     std::exit(3);
 }
 
-bool validateTestsPrecondition(std::string const &testDir) {
+bool
+validateTestsPrecondition(std::string const& testDir)
+{
   // Validate required test files can be located
   std::vector<std::string> EXPECTED_FILES(
-      {"semitransparent_voxels.vox", "spherical.txt"});
-  for (std::string &expectedFile : EXPECTED_FILES) {
+    { "semitransparent_voxels.vox", "spherical.txt" });
+  for (std::string& expectedFile : EXPECTED_FILES) {
     std::stringstream ss;
     char const pathsep = boost::filesystem::path::preferred_separator;
     ss << testDir << pathsep << expectedFile;

--- a/src/test/Tests.cpp
+++ b/src/test/Tests.cpp
@@ -1,7 +1,6 @@
 #include <test/AssetLoadingTest.h>
 #include <test/BaseTest.h>
 #include <test/DiscreteTimeTest.h>
-#include <test/SnapToSurfaceTest.h>
 #include <test/EnergyModelsTest.h>
 #include <test/ExprTreeTest.h>
 #include <test/FluxionumTest.h>
@@ -17,6 +16,7 @@
 #include <test/RigidMotionTest.h>
 #include <test/ScenePartSplitTest.h>
 #include <test/SerializationTest.h>
+#include <test/SnapToSurfaceTest.h>
 #include <test/SurveyCopyTest.h>
 #include <test/VoxelParsingTest.h>
 
@@ -35,27 +35,24 @@ using namespace HeliosTests;
  * @param testDir Path to directory containing test data
  * @return True if preconditions are satisfied, false otherwise
  */
-bool
-validateTestsPrecondition(std::string const& testDir);
+bool validateTestsPrecondition(std::string const &testDir);
 
-void
-doTests(std::string const& testDir)
-{
+void doTests(std::string const &testDir) {
   // Validate current working directory
   if (!validateTestsPrecondition(testDir)) {
     std::cout
-      << "WARNING! You might not be inside helios root directory.\n\t"
-         "This might cause tests to fail.\n"
-         "Please, change to helios root directory.\n"
-         "Alternatively, specify path to directory containing required test "
-         "files with:\n\t --testDir <path>\n\n"
-         "If this warning persists then probably test data "
-         "files cannot be located.\n"
-         "Get sure files can be located and accessed in your system.\n"
-         "If the problem persists, please report it\n\n"
-         "Current test files directory is: \""
-      << testDir << "\"\n"
-      << std::endl;
+        << "WARNING! You might not be inside helios root directory.\n\t"
+           "This might cause tests to fail.\n"
+           "Please, change to helios root directory.\n"
+           "Alternatively, specify path to directory containing required test "
+           "files with:\n\t --testDir <path>\n\n"
+           "If this warning persists then probably test data "
+           "files cannot be located.\n"
+           "Get sure files can be located and accessed in your system.\n"
+           "If the problem persists, please report it\n\n"
+           "Current test files directory is: \""
+        << testDir << "\"\n"
+        << std::endl;
   }
 
   // ***  T E S T S  *** //
@@ -125,13 +122,11 @@ doTests(std::string const& testDir)
     std::exit(3);
 }
 
-bool
-validateTestsPrecondition(std::string const& testDir)
-{
+bool validateTestsPrecondition(std::string const &testDir) {
   // Validate required test files can be located
   std::vector<std::string> EXPECTED_FILES(
-    { "semitransparent_voxels.vox", "spherical.txt" });
-  for (std::string& expectedFile : EXPECTED_FILES) {
+      {"semitransparent_voxels.vox", "spherical.txt"});
+  for (std::string &expectedFile : EXPECTED_FILES) {
     std::stringstream ss;
     char const pathsep = boost::filesystem::path::preferred_separator;
     ss << testDir << pathsep << expectedFile;

--- a/src/test/Tests.cpp
+++ b/src/test/Tests.cpp
@@ -1,6 +1,7 @@
 #include <test/AssetLoadingTest.h>
 #include <test/BaseTest.h>
 #include <test/DiscreteTimeTest.h>
+#include <test/SnapToSurfaceTest.h>
 #include <test/EnergyModelsTest.h>
 #include <test/ExprTreeTest.h>
 #include <test/FluxionumTest.h>
@@ -101,6 +102,9 @@ doTests(std::string const& testDir)
 
   ScenePartSplitTest scenePartSplitTest;
   passed &= scenePartSplitTest.test(std::cout, TEST_COLOR);
+
+  SnapToSurfaceTest snapToSurfaceTest;
+  passed &= snapToSurfaceTest.test(std::cout, TEST_COLOR);
 
   ExprTreeTest exprTreeTest;
   passed &= exprTreeTest.test(std::cout, TEST_COLOR);


### PR DESCRIPTION
snapToSurface adds optional surface-snapped return positioning for full-waveform outputs.
When enabled (and beamSampleQuality > 1), each detected waveform peak is matched to contributing discrete subray hits and assigned to the innermost contributing subray ring (tie-break: shortest distance). This updates the return distance/direction to a discrete surface hit while preserving existing full-wave peak detection and intensity estimation. If snapping is unavailable for a peak, behaviour falls back to closest-by-distance matching.


- Adds snapToSurface to FWFSettings (default false) for backwards-compatible behaviour.
- Adds XML attribute parsing for FWFSettings.
- Implements pipeline support in FullWaveformPulseRunnable: records discrete subray returns, validates peak contributors by waveform-bin contribution, applies snap selection, and falls back to legacy matching when needed.
- No processing change when snapToSurface is false or beamSampleQuality == 1.
- Adds dedicated unit tests covering innermost-ring selection, tie-breaking, and fallback behaviour.
- Adds runtime startup notice indicating how many devices have snapToSurface active.
- Includes demo survey/scene assets for slant-angle stress testing.