### PR TITLE
fix to make a correct deepcopy of ScenePart

### DIFF
--- a/python/helios/helios_python.cpp
+++ b/python/helios/helios_python.cpp
@@ -1009,9 +1009,10 @@ PYBIND11_MODULE(_helios, m)
 
   py::class_<ScenePart, std::shared_ptr<ScenePart>> scene_part(m, "ScenePart");
   scene_part.def(py::init<>())
-    .def(py::init<const ScenePart&, bool>(),
+    .def(py::init<const ScenePart&, bool, bool>(),
          py::arg("sp"),
-         py::arg("shallowPrimitives") = false)
+         py::arg("shallowPrimitives") = false,
+         py::arg("resetVerticesToCanonicalPosition") = true)
 
     .def_readwrite("origin", &ScenePart::mOrigin)
     .def_readwrite("rotation", &ScenePart::mRotation)

--- a/src/assetloading/ScenePart.cpp
+++ b/src/assetloading/ScenePart.cpp
@@ -10,7 +10,9 @@
 
 // ***  CONSTRUCTION / DESTRUCTION  *** //
 // ************************************ //
-ScenePart::ScenePart(ScenePart const& sp, bool const shallowPrimitives)
+ScenePart::ScenePart(ScenePart const& sp,
+                     bool const shallowPrimitives,
+                     bool const resetVerticesToCanonicalPosition)
 {
   this->centroid = sp.centroid;
   this->bound = sp.bound;
@@ -26,6 +28,7 @@ ScenePart::ScenePart(ScenePart const& sp, bool const shallowPrimitives)
   this->mEnv = nullptr; // TODO Copy this too
 
   this->primitiveType = sp.primitiveType;
+  this->subpartLimit = sp.subpartLimit;
   this->mPrimitives = std::vector<Primitive*>(0);
   Primitive* p;
 
@@ -33,15 +36,23 @@ ScenePart::ScenePart(ScenePart const& sp, bool const shallowPrimitives)
     for (size_t i = 0; i < sp.mPrimitives.size(); ++i) {
       this->mPrimitives.push_back(sp.mPrimitives[i]);
     }
-  } else {
-    for (size_t i = 0; i < sp.mPrimitives.size(); ++i) {
-      p = sp.mPrimitives[i]->clone();
-      p->part = sp.mPrimitives[i]->part;
-      this->mPrimitives.push_back(p);
-    }
+    return;
   }
+  for (Primitive* src : sp.mPrimitives) {
+    Primitive* p = src->clone();
+    if (resetVerticesToCanonicalPosition) {
+      Vertex* v = p->getVertices();
+      for (std::size_t i = 0; i < p->getNumVertices(); ++i) {
 
-  this->subpartLimit = sp.subpartLimit;
+        v[i].reset_to_canonical_position();
+      }
+      p->update();
+    }
+
+    p->part = nullptr;
+
+    this->mPrimitives.push_back(p);
+  }
 }
 
 // ***  COPY / MOVE OPERATORS  *** //

--- a/src/assetloading/ScenePart.h
+++ b/src/assetloading/ScenePart.h
@@ -165,7 +165,9 @@ public:
     : primitiveType(PrimitiveType::NONE)
   {
   }
-  ScenePart(ScenePart const& sp, bool const shallowPrimitives = false);
+  ScenePart(ScenePart const& sp,
+            bool const shallowPrimitives = false,
+            bool const resetVerticesToCanonicalPosition = true);
   virtual ~ScenePart() {}
 
   // ***  COPY / MOVE OPERATORS  *** //

--- a/src/scene/Scene.cpp
+++ b/src/scene/Scene.cpp
@@ -63,7 +63,8 @@ Scene::Scene(Scene& s)
     }
     for (ScenePart* sp :
          _parts) { // Handle primitives associated with ScenePart
-      std::shared_ptr<ScenePart> spc = std::make_shared<ScenePart>(*sp);
+      std::shared_ptr<ScenePart> spc =
+        std::make_shared<ScenePart>(*sp, false, false);
       for (Primitive* p : spc->mPrimitives) {
         p->part = spc;
         this->primitives.push_back(p);
@@ -128,7 +129,10 @@ Scene::finalizeLoading(bool const safe)
   for (Primitive* p : primitives) {
     Vertex* v = p->getVertices();
     for (std::size_t i = 0; i < p->getNumVertices(); i++) {
-      v[i].pos = v[i].pos - diff;
+      if (!v[i].posOrigin.has_value()) {
+        v[i].posOrigin = v[i].pos;
+      }
+      v[i].pos = *v[i].posOrigin - diff;
     }
     p->update();
   }

--- a/src/scene/StaticScene.h
+++ b/src/scene/StaticScene.h
@@ -65,6 +65,13 @@ public:
    */
   inline void appendStaticObject(std::shared_ptr<ScenePart> obj)
   {
+    if (obj == nullptr)
+      return;
+    for (Primitive* p : obj->mPrimitives) {
+      if (p == nullptr)
+        continue;
+      p->part = obj;
+    }
     staticObjs.push_back(obj);
   }
   /**

--- a/src/scene/primitives/Vertex.cpp
+++ b/src/scene/primitives/Vertex.cpp
@@ -8,6 +8,9 @@ Vertex::Vertex(const Vertex& v)
   this->normal = glm::dvec3(v.normal);
   this->color = Color4f(v.color);
   this->texcoords = glm::dvec2(v.texcoords);
+  if (v.posOrigin.has_value()) {
+    this->posOrigin = glm::dvec3(*v.posOrigin);
+  }
 }
 
 // ***  M E T H O D S  *** //

--- a/src/scene/primitives/Vertex.h
+++ b/src/scene/primitives/Vertex.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "Color4f.h"
 #include <glm/glm.hpp>
 #include <glm/gtx/hash.hpp>
+#include <optional>
 #include <ostream>
-
-#include "Color4f.h"
 
 /**
  * @brief Class representing a vertex
@@ -18,6 +18,10 @@ public:
    * @brief Vertex 3D position
    */
   glm::dvec3 pos;
+  /**
+   * @brief Original vertex position before translation to origin
+   */
+  std::optional<glm::dvec3> posOrigin;
   /**
    * @brief Vertex normal vector
    */
@@ -93,6 +97,17 @@ public:
    */
   inline double getZ() const { return this->pos.z; }
 
+  /**
+   * @brief Reset vertex position to its original position after copy
+   * @see Vertex::posOrigin
+   */
+  inline void reset_to_canonical_position()
+  {
+    if (posOrigin.has_value()) {
+      pos = *posOrigin;
+      posOrigin.reset();
+    }
+  }
   /**
    * @brief Compare if two vertex are equal
    *

--- a/tests/python/test_scene.py
+++ b/tests/python/test_scene.py
@@ -1620,3 +1620,67 @@ def test_scene_part_from_o3d_mesh_accepts_all_supported_mesh_attributes(o3d_mesh
 
     scene_part = ScenePart.from_open3d(geometry)
     assert len(scene_part._cpp_object.primitives) > 0
+
+
+def test_survey_measurement_and_trajectory_positions_are_reproducible():
+    groundplane = ScenePart.from_obj(
+        "data/sceneparts/basic/groundplane/groundplane.obj"
+    )
+    cube = ScenePart.from_obj("data/sceneparts/toyblocks/sphere.obj")
+
+    scanner0 = scanner_from_name("riegl_vz_400")
+    platform0 = platform_from_name("tripod")
+
+    fwf_settings = FullWaveformSettings(
+        bin_size=0.1 * units.ns,
+    )
+
+    scanner_settings = ScannerSettings(
+        pulse_frequency=300_000 * units.Hz,
+        vertical_resolution=0.03 * units.deg,
+        horizontal_resolution=0.03 * units.deg,
+        min_vertical_angle=-40 * units.deg,
+        max_vertical_angle=60 * units.deg,
+    )
+
+    def run_survey(scene, scanner, platform):
+        survey = Survey(
+            scanner=scanner,
+            platform=platform,
+            scene=scene,
+            full_waveform_settings=fwf_settings,
+        )
+        survey.add_leg(
+            x=0,
+            y=-10,
+            z=0,
+            scanner_settings=scanner_settings,
+            rotation_start_angle=-45 * units.deg,
+            rotation_stop_angle=45 * units.deg,
+        )
+        return survey.run()
+
+    scene_0 = StaticScene([groundplane, cube])
+    meas0, traj0 = run_survey(scene_0, scanner0, platform0)
+
+    scene_1 = StaticScene([copy.deepcopy(groundplane), copy.deepcopy(cube)])
+    meas1, traj1 = run_survey(
+        scene_1,
+        copy.deepcopy(scanner0),
+        copy.deepcopy(platform0),
+    )
+
+    scene_2 = copy.deepcopy(scene_0)
+    meas2, traj2 = run_survey(
+        scene_2,
+        copy.deepcopy(scanner0),
+        copy.deepcopy(platform0),
+    )
+
+    assert len(meas0) == len(meas1) == len(meas2)
+    assert len(traj0) == len(traj1) == len(traj2)
+
+    assert np.allclose(meas0["position"][0], meas1["position"][0], rtol=1e-1, atol=1e-1)
+    assert np.allclose(meas0["position"][0], meas2["position"][0], rtol=1e-1, atol=1e-1)
+    assert np.allclose(traj0["position"][0], traj1["position"][0], rtol=1e-1, atol=1e-1)
+    assert np.allclose(traj0["position"][0], traj2["position"][0], rtol=1e-1, atol=1e-1)


### PR DESCRIPTION
this pr should fix Issue #836 . The original problem was that `finalizeLoading()` modified `Vertex::pos` directly, so the  coordinates were lost after finalization. Now Vertex stores both `pos` and `posOrigin`: `pos` can be shifted for runtime calculations, while `posOrigin` preserves the original position data for safe copying and re-finalization.