### PR TITLE
Feat/scene part

### DIFF
--- a/python/helios/data/serialization_schema.json
+++ b/python/helios/data/serialization_schema.json
@@ -705,6 +705,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "id": {},
         "force_on_ground": {}
       }
     },

--- a/python/helios/helios_python.cpp
+++ b/python/helios/helios_python.cpp
@@ -1055,7 +1055,29 @@ PYBIND11_MODULE(_helios, m)
         }
       })
     .def_property("centroid", &ScenePart::getCentroid, &ScenePart::setCentroid)
-    .def_property("id", &ScenePart::getId, &ScenePart::setId)
+    .def_property(
+      "id",
+      [](const ScenePart& self) -> py::object {
+        const std::string& value = self.getId();
+
+        if (value.empty()) {
+          return py::none();
+        }
+
+        try {
+          return py::int_(std::stoi(value));
+        } catch (...) {
+          throw py::value_error("ScenePart.id contains non-integer value: '" +
+                                value + "'");
+        }
+      },
+      [](ScenePart& self, py::object value) {
+        if (value.is_none()) {
+          self.setId("");
+        } else {
+          self.setId(std::to_string(value.cast<int>()));
+        }
+      })
     .def_property(
       "dyn_object_step",
       [](const ScenePart& self) -> size_t {

--- a/python/helios/scene.py
+++ b/python/helios/scene.py
@@ -183,6 +183,7 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
     :type force_on_ground: Union[ForceOnGroundStrategy, PositiveInt]
     """
 
+    id: int | None = None
     force_on_ground: Union[ForceOnGroundStrategy, PositiveInt] = (
         ForceOnGroundStrategy.NONE
     )
@@ -333,7 +334,12 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
 
     @classonlymethod
     @validate_call
-    def from_obj(cls, obj_file: AssetPath, up_axis: Literal["y", "z"] = "z"):
+    def from_obj(
+        cls,
+        obj_file: AssetPath,
+        up_axis: Literal["y", "z"] = "z",
+        id: Optional[int] = None,
+    ):
         """
         Load the scene part from an OBJ file.
 
@@ -341,8 +347,10 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
 
         :param obj_file: The path to the OBJ file to load the scene part from. Can potentially contain wildcards ('*').
         :param up_axis: The up axis to use for the loaded scene part.
+        :param id: Optional ID to assign to the scene part. If not provided, the ID will be automatically assigned later.
         :type obj_file: AssetPath
         :type up_axis: Literal["y", "z"]
+        :type id: Optional[int]
 
         :return: The loaded scene part.
         :rtype: ScenePart
@@ -353,22 +361,26 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         )
 
         scene_part = cls._from_cpp(_cpp_part)
+        scene_part.id = id
         scene_part._set_constructor_provenance(
             "from_obj",
             obj_file=obj_file,
             up_axis=up_axis,
+            id=id,
         )
         return scene_part
 
     @classonlymethod
     @validate_call
-    def from_tiff(cls, tiff_file: AssetPath):
+    def from_tiff(cls, tiff_file: AssetPath, id: Optional[int] = None):
         """Load the scene part from a TIFF file.
 
         For paths (potentially) containing wildcards, use 'ScenePart.from_tiffs()' instead!
 
         :param tiff_file: The path to the TIFF file to load the scene part from.
+        :param id: Optional ID to assign to the scene part. If not provided, the ID will be automatically assigned later.
         :type tiff_file: AssetPath
+        :type id: Optional[int]
 
         :return: The loaded scene part.
         :rtype: ScenePart
@@ -379,15 +391,22 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         )
 
         scene_part = cls._from_cpp(_cpp_part)
+        scene_part.id = id
         scene_part._set_constructor_provenance(
             "from_tiff",
             tiff_file=tiff_file,
+            id=id,
         )
         return scene_part
 
     @classonlymethod
     @validate_call
-    def from_objs(cls, obj_files: MultiAssetPath, up_axis: Literal["y", "z"] = "z"):
+    def from_objs(
+        cls,
+        obj_files: MultiAssetPath,
+        up_axis: Literal["y", "z"] = "z",
+        shared_id: Optional[int] = None,
+    ):
         """Load multiple scene parts from OBJ files
 
         Expects a single Path containing some (or none) wildcards ('*').
@@ -395,31 +414,35 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
 
         :param obj_files: The path to the OBJ files to load the scene parts from. Can potentially contain wildcards ('*').
         :param up_axis: The up axis to use for the loaded scene parts.
+        :param shared_id: Optional ID to assign to all loaded scene parts. If not provided, different IDs will be automatically assigned later.
         :type obj_files: MultiAssetPath
         :type up_axis: Literal["y", "z"]
+        :type shared_id: Optional[int]
 
         :return: The loaded scene parts.
         :rtype: list[ScenePart]
         """
-        return [ScenePart.from_obj(obj, up_axis) for obj in obj_files]
+        return [ScenePart.from_obj(obj, up_axis, shared_id) for obj in obj_files]
 
     @classonlymethod
     @validate_call
-    def from_tiffs(cls, tiff_files: MultiAssetPath):
+    def from_tiffs(cls, tiff_files: MultiAssetPath, shared_id: Optional[int] = None):
         """Load multiple scene parts from TIFF files
 
         Expects a single Path containing some (or none) wildcards ('*').
         Supports '**' for matching multiple directories.
 
         :param tiff_files: The path to the TIFF files to load the scene parts from. Can potentially contain wildcards ('*').
+        :param shared_id: Optional ID to assign to all loaded scene parts. If not provided, different IDs will be automatically assigned later.
         :type tiff_files: MultiAssetPath
+        :type shared_id: Optional[int]
         :return: The loaded scene parts.
         :rtype: list[ScenePart]
 
         :return: The loaded scene parts.
         :rtype: list[ScenePart]
         """
-        return [ScenePart.from_tiff(tiff) for tiff in tiff_files]
+        return [ScenePart.from_tiff(tiff, shared_id) for tiff in tiff_files]
 
     @classonlymethod
     @validate_call
@@ -437,6 +460,7 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         normals_file_columns: list[NonNegativeInt] = [3, 4, 5],
         rgb_file_columns: list[NonNegativeInt] = [6, 7, 8],
         snap_neighbor_normal: bool = False,
+        id: Optional[int] = None,
     ):
         """
         Load the scene part from an XYZ file.
@@ -451,6 +475,7 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         :param normals_file_columns: The columns in the XYZ file to use for the normal components if the XYZ file contains normals. The default is [3, 4, 5].
         :param rgb_file_columns: The columns in the XYZ file to use for the RGB components if the XYZ file contains RGB values. The default is [6, 7, 8].
         :param snap_neighbor_normal: Whether to snap the normal of points in the XYZ file that do not have a normal to the normal of their nearest neighbor that has a normal.
+        :param id: Optional ID to assign to the scene part. If not provided, the ID will be automatically assigned later.
         :type xyz_file: AssetPath
         :type voxel_size: PositiveFloat
         :type separator: Optional[str]
@@ -461,6 +486,7 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         :type normals_file_columns: list[NonNegativeInt]
         :type rgb_file_columns: list[NonNegativeInt]
         :type snap_neighbor_normal: bool
+        :type id: Optional[int]
 
         :return: The loaded scene part.
         :rtype: ScenePart
@@ -488,6 +514,7 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         )
 
         scene_part = cls._from_cpp(_cpp_part)
+        scene_part.id = id
         scene_part._set_constructor_provenance(
             "from_xyz",
             xyz_file=xyz_file,
@@ -500,6 +527,7 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
             normals_file_columns=normals_file_columns,
             rgb_file_columns=rgb_file_columns,
             snap_neighbor_normal=snap_neighbor_normal,
+            id=id,
         )
         return scene_part
 
@@ -519,6 +547,7 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         normals_file_columns: list[NonNegativeInt] = [3, 4, 5],
         rgb_file_columns: list[NonNegativeInt] = [6, 7, 8],
         snap_neighbor_normal: bool = False,
+        shared_id: Optional[int] = None,
     ):
         """
         Load multiple scene parts from XYZ files.
@@ -538,6 +567,7 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         :param normals_file_columns: The columns in the XYZ file to use for the normal components if the XYZ file contains normals. The default is [3, 4, 5].
         :param rgb_file_columns: The columns in the XYZ file to use for the RGB components if the XYZ file contains RGB values. The default is [6, 7, 8].
         :param snap_neighbor_normal: Whether to snap the normal of points in the XYZ file that do not have a normal to the normal of their nearest neighbor that has a normal.
+        :param shared_id: Optional ID to assign to all loaded scene parts. If not provided, the ID will be automatically assigned later.
         :type xyz_file: AssetPath
         :type voxel_size: PositiveFloat
         :type separator: Optional[str]
@@ -548,6 +578,7 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         :type normals_file_columns: list[NonNegativeInt]
         :type rgb_file_columns: list[NonNegativeInt]
         :type snap_neighbor_normal: bool
+        :type shared_id: Optional[int]
 
         :return: The loaded scene parts.
         :rtype: list[ScenePart]
@@ -564,6 +595,7 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
                 normals_file_columns,
                 rgb_file_columns,
                 snap_neighbor_normal,
+                shared_id,
             )
             for xyz in xyz_files
         ]
@@ -577,6 +609,7 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         intersection_argument: Optional[float] = None,
         random_shift: bool = False,
         ladlut_path: Optional[str] = None,
+        id: Optional[int] = None,
     ):
         """Load the scene part from a VOX file.
 
@@ -585,11 +618,13 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         :param intersection_argument: Scaling factor; only used for intersection mode 'scaled'.
         :param random_shift: Whether to apply a random shift to the scaled cubes within the original voxel resolution; only used for intersection mode 'scaled'.
         :param ladlut_path: The path to the txt file with look-up-tables (LUTs) for custom leaf angle distributions (LADs). See `data/lut` for examples.
+        :param id: Optional ID to assign to the scene part. If not provided, the ID will be automatically assigned later.
         :type vox_file: AssetPath
         :type intersection_mode: Literal["scaled", "fixed", "transmittive"]
         :type intersection_argument: Optional[float]
         :type random_shift: bool
         :type ladlut_path: Optional[str]
+        :type id: Optional[int]
 
         :return: The loaded scene part.
         :rtype: ScenePart
@@ -610,6 +645,7 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         )
 
         scene_part = cls._from_cpp(_cpp_part)
+        scene_part.id = id
         scene_part._set_constructor_provenance(
             "from_vox",
             vox_file=vox_file,
@@ -617,6 +653,7 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
             intersection_argument=intersection_argument,
             random_shift=random_shift,
             ladlut_path=ladlut_path,
+            id=id,
         )
         return scene_part
 
@@ -636,6 +673,7 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         sparse: bool = True,
         estimate_normals: bool = False,
         snap_neighbor_normal: bool = False,
+        id: Optional[int] = None,
     ):
         """Load the scene part from a numpy array."""
 
@@ -660,8 +698,10 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
             rcols[2],
             snap_neighbor_normal,
         )
+        scene_part = cls._from_cpp(_cpp_part)
+        scene_part.id = id
 
-        return cls._from_cpp(_cpp_part)
+        return scene_part
 
     @classmethod
     def _compose_from_o3d_triangle_mesh(
@@ -669,6 +709,7 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         geometry,
         *,
         up_axis: Literal["y", "z"] = "z",
+        id: Optional[int] = None,
     ):
         if up_axis not in ("y", "z"):
             raise ValueError("`up_axis` must be either 'y' or 'z'.")
@@ -734,7 +775,8 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
             triangle_uvs,
             up_axis,
         )
-
+        scene_part = cls._from_cpp(_cpp_part)
+        scene_part.id = id
         return cls._from_cpp(_cpp_part)
 
     @classmethod
@@ -750,6 +792,7 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         sparse: bool = True,
         estimate_normals: bool = False,
         snap_neighbor_normal: bool = False,
+        id: Optional[int] = None,
     ):
         points = _as_array(
             geometry.points, dtype=np.float64, name="Open3D point cloud points"
@@ -805,11 +848,12 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
             sparse=sparse,
             estimate_normals=estimate_normals,
             snap_neighbor_normal=snap_neighbor_normal,
+            id=id,
         )
 
     @classonlymethod
     @validate_call
-    def from_open3d(cls, geometry, **kwargs):
+    def from_open3d(cls, geometry, id: Optional[int] = None, **kwargs):
         """
         Load the scene part from an Open3D geometry.
         The geometry can be either an open3d.geometry.TriangleMesh or an open3d.geometry.PointCloud.
@@ -817,7 +861,9 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         See below for the specific additional parameters that can be provided for each geometry type.
 
         :param geometry: The Open3D geometry to load the scene part from.
+        :param id: The ID to assign to the loaded scene part.
         :type geometry: open3d.geometry.TriangleMesh | open3d.geometry.PointCloud
+        :type id: Optional[int]
         :param kwargs: Additional parameters to use for loading the scene part, depending on the provided geometry:
             a) for open3d.geometry.TriangleMesh: `up_axis`;
             b) for open3d.geometry.PointCloud: `voxel_size`, `max_color_value`, `default_normal`, `sparse`, `estimate_normals`, `snap_neighbor_normal`
@@ -832,9 +878,9 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
                 "Open3D is required for `ScenePart.from_open3d`, but can't be installed via conda. Install it with `pip install open3d`."
             )
         if isinstance(geometry, open3d.geometry.TriangleMesh):
-            return cls._compose_from_o3d_triangle_mesh(geometry, **kwargs)
+            return cls._compose_from_o3d_triangle_mesh(geometry, id=id, **kwargs)
         if isinstance(geometry, open3d.geometry.PointCloud):
-            return cls._compose_from_o3d_pointcloud(geometry, **kwargs)
+            return cls._compose_from_o3d_pointcloud(geometry, id=id, **kwargs)
 
         raise TypeError(
             "Unsupported geometry type for `ScenePart.from_o3d`. "

--- a/python/helios/survey.py
+++ b/python/helios/survey.py
@@ -183,7 +183,8 @@ class Survey(Model, cpp_class=_helios.Survey):
 
         # also, for proper writing into the file, we need to set IDs for the scene parts
         for i, scene_part in enumerate(self.scene.scene_parts):
-            scene_part._cpp_object.id = str(i)
+            if scene_part.id is None:
+                scene_part.id = str(i)
 
         if output_settings.format in (OutputFormat.NPY, OutputFormat.LASPY):
             las_output, zip_output, export_to_file = False, False, False

--- a/python/helios/validation.py
+++ b/python/helios/validation.py
@@ -567,23 +567,30 @@ class Model(metaclass=ValidatedModelMetaClass):
     def _from_cpp(cls, value):
         params = {}
         for field, annot in get_all_annotations(cls).items():
-            if hasattr(value, field):
-                cpp_value = getattr(value, field)
-                if _is_optional(annot):
-                    T = _inner_optional_type(annot)
-                    params[field] = (
-                        None if cpp_value is None else T._from_cpp(cpp_value)
-                    )
-                    continue
+            if not hasattr(value, field):
+                continue
 
-                if not _is_iterable_annotation(annot):
-                    if hasattr(annot, "_from_cpp"):
-                        cpp_value = annot._from_cpp(cpp_value)
+            cpp_value = getattr(value, field)
+
+            if _is_optional(annot):
+                T = _inner_optional_type(annot)
+                if cpp_value is None:
+                    params[field] = None
+                elif hasattr(T, "_from_cpp"):
+                    params[field] = T._from_cpp(cpp_value)
                 else:
-                    args = get_args(annot)
-                    if hasattr(args[0], "_from_cpp"):
-                        cpp_value = [args[0]._from_cpp(v) for v in cpp_value]
-                params[field] = cpp_value
+                    params[field] = cpp_value
+                continue
+
+            if not _is_iterable_annotation(annot):
+                if hasattr(annot, "_from_cpp"):
+                    cpp_value = annot._from_cpp(cpp_value)
+            else:
+                args = get_args(annot)
+                if hasattr(args[0], "_from_cpp"):
+                    cpp_value = [args[0]._from_cpp(v) for v in cpp_value]
+
+            params[field] = cpp_value
 
         return cls(_cpp_object=value, **params)
 

--- a/tests/python/test_bindings.py
+++ b/tests/python/test_bindings.py
@@ -706,7 +706,7 @@ def test_leg_and_scanner_settings_thread_safety():
 def create_scene_part():
     # Create a ScenePart object
     scene_part = _helios.ScenePart()
-    scene_part.id = "TestPart"
+    scene_part.id = 0
     scene_part.origin = (1.0, 2.0, 3.0)
     scene_part.rotation = _helios.Rotation((0.0, 1.0, 0.0), 1.0)
     scene_part.origin = (1.0, 2.0, 3.0)
@@ -721,7 +721,7 @@ def test_scene_part():
     scene_part = create_scene_part()
 
     # Test properties
-    assert scene_part.id == "TestPart"
+    assert scene_part.id == 0
     assert scene_part.origin == (1.0, 2.0, 3.0)
     assert scene_part.rotation.axis == (0.0, 1.0, 0.0)
     assert scene_part.origin == (1.0, 2.0, 3.0)
@@ -730,14 +730,14 @@ def test_scene_part():
     assert scene_part.scale == 2.0
 
     # Modify properties
-    scene_part.id = "UpdatedPart"
+    scene_part.id = 2
     scene_part.origin = (4.0, 5.0, 6.0)
     scene_part.origin = (4.0, 5.0, 6.0)
     scene_part.rotation = _helios.Rotation((1.0, 0.0, 0.0), 2.0)
     scene_part.rotation = _helios.Rotation((1.0, 0.0, 0.0), 2.0)
     scene_part.scale = 3.0
 
-    assert scene_part.id == "UpdatedPart"
+    assert scene_part.id == 2
     assert scene_part.origin == (4.0, 5.0, 6.0)
     assert scene_part.rotation.axis == (1.0, 0.0, 0.0)
     assert scene_part.origin == (4.0, 5.0, 6.0)
@@ -776,7 +776,7 @@ def modify_scene_part_in_threads(scene_part, lock):
     def thread_function():
         with lock:
             for i in range(100):
-                scene_part.id = f"ThreadPart-{i}"
+                scene_part.id = i
                 scene_part.origin = (i, i + 1, i + 2)
                 # Assuming rotation is defined as (axis, angle)
                 axis = (i % 2, (i + 1) % 2, (i + 2) % 2)

--- a/tests/python/test_scene.py
+++ b/tests/python/test_scene.py
@@ -10,6 +10,7 @@ from helios.utils import *
 import copy
 import math
 from pathlib import Path
+from pydantic import ValidationError
 
 import _helios
 import laspy
@@ -196,11 +197,11 @@ def test_construct_scene_from_xml():
 
 
 def test_construct_scene_part_from_xml():
-    part = ScenePart.from_xml("data/scenes/toyblocks/toyblocks_scene.xml", id="0")
+    part = ScenePart.from_xml("data/scenes/toyblocks/toyblocks_scene.xml", id=0)
 
 
 def test_finalize_scene():
-    part = ScenePart.from_xml("data/scenes/toyblocks/toyblocks_scene.xml", id="0")
+    part = ScenePart.from_xml("data/scenes/toyblocks/toyblocks_scene.xml", id=0)
 
     scene = StaticScene(scene_parts=[part])
     assert len(scene._cpp_object.primitives) == 0
@@ -209,8 +210,8 @@ def test_finalize_scene():
 
 
 def test_scene_invalidation():
-    part = ScenePart.from_xml("data/scenes/toyblocks/toyblocks_scene.xml", id="0")
-    part2 = ScenePart.from_xml("data/scenes/toyblocks/toyblocks_scene.xml", id="0")
+    part = ScenePart.from_xml("data/scenes/toyblocks/toyblocks_scene.xml", id=0)
+    part2 = ScenePart.from_xml("data/scenes/toyblocks/toyblocks_scene.xml", id=0)
     scene = StaticScene(scene_parts=[part])
     scene._finalize()
 
@@ -876,7 +877,7 @@ def test_run_after_add_scene_part():
 def test_scenepart_flag_from_xml_set(xyz_file):
     from helios.utils import is_xml_loaded
 
-    part = ScenePart.from_xml("data/scenes/toyblocks/toyblocks_scene.xml", id="0")
+    part = ScenePart.from_xml("data/scenes/toyblocks/toyblocks_scene.xml", id=0)
     assert is_xml_loaded(part)
 
     part2 = ScenePart.from_vox(
@@ -1687,7 +1688,7 @@ def test_survey_measurement_and_trajectory_positions_are_reproducible():
 
 
 def test_take_vis_buffer_from_scene_part():
-    part = ScenePart.from_xml("data/scenes/toyblocks/toyblocks_scene.xml", id="0")
+    part = ScenePart.from_xml("data/scenes/toyblocks/toyblocks_scene.xml", id=0)
     buffers = part._get_visualization_buffers()
     triangle_vertices = np.asarray(buffers.triangle_vertices, dtype=np.float32)
     triangle_indices = np.asarray(buffers.triangle_indices, dtype=np.int32)
@@ -1695,3 +1696,114 @@ def test_take_vis_buffer_from_scene_part():
     assert triangle_vertices.shape[0] > 0
     assert triangle_vertices.shape[1] == 3
     assert triangle_indices.shape[0] > 0
+
+
+def test_change_sp_id():
+    part = ScenePart.from_xml("data/scenes/toyblocks/toyblocks_scene.xml", id=0)
+    assert part.id == 0
+    part.id = 1
+    assert part.id == 1
+
+    part2 = ScenePart.from_obj("data/sceneparts/toyblocks/cylinder.obj")
+    assert part2.id is None
+    part2.id = 5
+    assert part2.id == 5
+
+
+def test_provide_incorrect_id_type():
+    with pytest.raises(ValidationError):
+        ScenePart.from_obj("data/sceneparts/toyblocks/cylinder.obj", id="not_an_int")
+    with pytest.raises(ValidationError):
+        ScenePart.from_obj("data/sceneparts/toyblocks/cylinder.obj", id=3.14)
+
+
+def test_read_xyz_w_id(xyz_file_comma):
+    part = ScenePart.from_xyz(str(xyz_file_comma), separator=",", voxel_size=1.0, id=42)
+    assert part.id == 42
+
+
+def test_read_xyzs_w_id(xyz_parts_dir):
+    parts = ScenePart.from_xyzs(
+        str(xyz_parts_dir / "part[12].xyz"), voxel_size=1.0, shared_id=99
+    )
+    assert len(parts) > 1
+    assert all(part.id == 99 for part in parts)
+
+
+def test_read_obj_w_id():
+    part = ScenePart.from_obj("data/sceneparts/toyblocks/cylinder.obj", id=7)
+    assert part.id == 7
+
+
+def test_read_objs_w_id():
+    parts = ScenePart.from_objs("data/sceneparts/basic/**/*.obj", shared_id=13)
+    assert all(part.id == 13 for part in parts)
+
+
+def test_read_vox_w_id():
+    part = ScenePart.from_vox(
+        "data/test/semitransparent_voxels.vox", intersection_mode="transmittive", id=21
+    )
+    assert part.id == 21
+
+
+def test_read_tiff_w_id():
+    part = ScenePart.from_tiff("data/test/dem_hd_sub.tif", id=55)
+    assert part.id == 55
+
+
+def test_read_tiffs_w_id():
+    parts = ScenePart.from_tiffs("data/test/dem_hd_sub.tif", shared_id=88)
+    assert all(part.id == 88 for part in parts)
+
+
+def test_read_numpy_w_id():
+    points = np.array(
+        [
+            [0.0, 0.0, 0.0, 255, 0, 0],
+            [1.0, 0.0, 0.0, 0, 255, 0],
+            [0.0, 1.0, 0.0, 0, 0, 255],
+            [1.0, 1.0, 0.0, 255, 255, 0],
+        ]
+    )
+    scene_part = ScenePart.from_numpy_array(
+        points,
+        voxel_size=1.0,
+        max_color_value=255.0,
+        rgb_file_columns=[3, 4, 5],
+        default_normal=[0.0, 0.0, 1.0],
+        id=123,
+    )
+    assert scene_part.id == 123
+
+
+def test_read_o3d_pc_w_id():
+    points = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0],
+        ]
+    )
+    colors = np.array(
+        [
+            [255, 0, 0],
+            [0, 255, 0],
+            [0, 0, 255],
+            [255, 255, 0],
+        ]
+    )
+    pcd = o3d.geometry.PointCloud()
+    pcd.points = o3d.utility.Vector3dVector(points)
+    pcd.colors = o3d.utility.Vector3dVector(colors)
+    scene_part = ScenePart.from_open3d(
+        pcd, voxel_size=1.0, max_color_value=255.0, id=456
+    )
+    assert scene_part.id == 456
+
+
+def test_read_o3d_mesh_w_id(o3d_mesh_file):
+    geometry = o3d.io.read_triangle_mesh(str(o3d_mesh_file))
+    scene_part = ScenePart.from_open3d(geometry, id=789)
+    assert scene_part.id == 789

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -991,7 +991,7 @@ def test_to_bundle_passes_binary_flag(tmp_path):
 
 def test_from_binary_stores_provenance(tmp_path):
     scene = StaticScene(
-        scene_parts=[ScenePart.from_obj("data/sceneparts/basic/box/box100.obj")]
+        scene_parts=[ScenePart.from_obj("data/sceneparts/basic/box/box100.obj", id=4)]
     )
     binary_path = tmp_path / "scene.bin"
     scene.to_binary(binary_path)


### PR DESCRIPTION
This pr should fix #768 . Now the user can specify `id` for each scene_part at any time. For multiple-files-at-once reading (i.e. `from_*s` ) there is an int `shared_id` parameter, so you can specify if all parts loaded via this method should have similar `id` / `hitObjectId` , as discussed in #768 