### PR TITLE
Minimal implementation of dynamic scenes in the Python API

### DIFF
--- a/data/test/dynamic_scene.xml
+++ b/data/test/dynamic_scene.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document>
+    <scene id="dynamic_test_scene" name="Dynamic test scene" dynStep="1" kdtDynStep="1">
+        <part id="1">
+            <filter type="objloader">
+                <param type="string" key="filepath" value="data/sceneparts/basic/groundplane/groundplane.obj"/>
+            </filter>
+            <filter type="scale">
+                <param type="double" key="scale" value="120"/>
+            </filter>
+            <filter type="translate">
+                <param type="vec3" key="offset" value="50;0;0"/>
+            </filter>
+        </part>
+        <part id="2" dynStep="1" kdtDynStep="1">
+            <filter type="objloader">
+                <param type="string" key="filepath" value="data/sceneparts/toyblocks/cube.obj"/>
+            </filter>
+            <filter type="rotate">
+                <param type="rotation" key="rotation">
+                    <rot angle_deg="45" axis="z"/>
+                </param>
+            </filter>
+            <filter type="scale">
+                <param type="double" key="scale" value="0.75"/>
+            </filter>
+            <filter type="translate">
+                <param type="vec3" key="offset" value="-40;-5;0"/>
+            </filter>
+            <dmotion id="test_cube_translation" loop="0">
+                <motion type="translation" vec="0.002;0;0"/>
+            </dmotion>
+        </part>
+    </scene>
+</document>

--- a/data/test/dynamic_scene_static_control.xml
+++ b/data/test/dynamic_scene_static_control.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document>
+    <scene id="dynamic_test_static_control" name="Dynamic test static control">
+        <part id="1">
+            <filter type="objloader">
+                <param type="string" key="filepath" value="data/sceneparts/basic/groundplane/groundplane.obj"/>
+            </filter>
+            <filter type="scale">
+                <param type="double" key="scale" value="120"/>
+            </filter>
+            <filter type="translate">
+                <param type="vec3" key="offset" value="50;0;0"/>
+            </filter>
+        </part>
+        <part id="2">
+            <filter type="objloader">
+                <param type="string" key="filepath" value="data/sceneparts/toyblocks/cube.obj"/>
+            </filter>
+            <filter type="rotate">
+                <param type="rotation" key="rotation">
+                    <rot angle_deg="45" axis="z"/>
+                </param>
+            </filter>
+            <filter type="scale">
+                <param type="double" key="scale" value="0.75"/>
+            </filter>
+            <filter type="translate">
+                <param type="vec3" key="offset" value="-40;-5;0"/>
+            </filter>
+        </part>
+    </scene>
+</document>

--- a/data/test/dynamic_survey.xml
+++ b/data/test/dynamic_survey.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document>
+    <survey name="dynamic_test_survey"
+            scene="data/test/dynamic_scene.xml#dynamic_test_scene"
+            platform="data/platforms.xml#tripod"
+            scanner="data/scanners_tls.xml#riegl_vz400">
+        <leg>
+            <platformSettings x="-30" y="-30" z="0" onGround="true"/>
+            <scannerSettings active="true"
+                             pulseFreq_hz="5000"
+                             verticalAngleMin_deg="-40"
+                             verticalAngleMax_deg="60"
+                             scanFreq_hz="120"
+                             headRotatePerSec_deg="-60"
+                             headRotateStart_deg="340"
+                             headRotateStop_deg="280"/>
+        </leg>
+    </survey>
+</document>

--- a/doc/pythonapi.rst
+++ b/doc/pythonapi.rst
@@ -56,6 +56,9 @@ Scene
 .. autoapiclass:: helios.StaticScene
    :members:
 
+.. autoapiclass:: helios.DynamicScene
+   :members:
+
 .. autoapiclass:: helios.ScenePart
    :members:
 

--- a/python/helios/__init__.py
+++ b/python/helios/__init__.py
@@ -16,7 +16,7 @@ from helios.platforms import (
     platform_from_name,
 )
 from helios.scanner import Scanner, ScannerSettings, list_scanners, scanner_from_name
-from helios.scene import StaticScene, ScenePart, BoundingBox
+from helios.scene import DynamicScene, StaticScene, ScenePart, BoundingBox
 from helios.settings import (
     ExecutionSettings,
     ForceOnGroundStrategy,

--- a/python/helios/data/serialization_schema.json
+++ b/python/helios/data/serialization_schema.json
@@ -79,6 +79,9 @@
                 "$ref": "#/$defs/model_document_helios_scene_BoundingBox"
               },
               {
+                "$ref": "#/$defs/model_document_helios_scene_DynamicScene"
+              },
+              {
                 "$ref": "#/$defs/model_document_helios_scene_Material"
               },
               {
@@ -133,6 +136,7 @@
             "helios.scanner.ScannerSettings",
             "helios.scanner.ScannerSettingsBase",
             "helios.scene.BoundingBox",
+            "helios.scene.DynamicScene",
             "helios.scene.Material",
             "helios.scene.ScenePart",
             "helios.scene.StaticScene",
@@ -453,6 +457,21 @@
         }
       }
     },
+    "model_document_helios_scene_DynamicScene": {
+      "type": "object",
+      "required": [
+        "model_class",
+        "fields"
+      ],
+      "properties": {
+        "model_class": {
+          "const": "helios.scene.DynamicScene"
+        },
+        "fields": {
+          "$ref": "#/$defs/fields_helios_scene_DynamicScene"
+        }
+      }
+    },
     "model_document_helios_scene_Material": {
       "type": "object",
       "required": [
@@ -685,6 +704,11 @@
       "maxProperties": 0
     },
     "fields_helios_scene_BoundingBox": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 0
+    },
+    "fields_helios_scene_DynamicScene": {
       "type": "object",
       "additionalProperties": false,
       "maxProperties": 0

--- a/python/helios/helios_python.cpp
+++ b/python/helios/helios_python.cpp
@@ -1435,6 +1435,9 @@ PYBIND11_MODULE(_helios, m)
     .def("clear_static_object_parts", &StaticScene::clearStaticObjects)
     .def("shutdown", &StaticScene::shutdown);
 
+  py::class_<DynScene, StaticScene, std::shared_ptr<DynScene>>(m,
+                                                               "DynamicScene");
+
   py::class_<Platform, std::shared_ptr<Platform>> platform(m, "Platform");
   platform.def(py::init<>())
     .def(py::init<Platform&>(), py::arg("platform"))
@@ -3340,6 +3343,11 @@ PYBIND11_MODULE(_helios, m)
   m.def("read_scanner_from_xml", &readScannerFromXml);
   m.def("read_platform_from_xml", &readPlatformFromXml);
   m.def("read_scene_from_xml", &readSceneFromXml);
+  m.def("read_dynamic_scene_from_xml",
+        &readDynamicSceneFromXml,
+        py::arg("file_path"),
+        py::arg("assets_path"),
+        py::arg("build_kd_grove") = true);
   m.def("read_scene_part_from_xml", &readScenePartFromXml);
 
   // Add helper function for scene handling

--- a/python/helios/live.py
+++ b/python/helios/live.py
@@ -5,7 +5,7 @@ from helios.callbacks import (
     HookEndOfLegPolicy,
 )
 from helios.utils import extract_position, _is_in_jupyter
-from helios.scene import StaticScene
+from helios.scene import DynamicScene, StaticScene
 
 import numpy as np
 import threading
@@ -127,6 +127,11 @@ class LiveViewer:
     def attach_to_survey(self, survey) -> None:
         if self.scene is not None:
             raise RuntimeError("attach_to_survey already called")
+        if isinstance(survey.scene, DynamicScene):
+            raise NotImplementedError(
+                "Live viewing is not supported for DynamicScene because the "
+                "viewer cannot update moving geometry yet."
+            )
         self.scene = survey.scene
 
     def callbacks(self):

--- a/python/helios/platforms.py
+++ b/python/helios/platforms.py
@@ -1,4 +1,4 @@
-from helios.scene import StaticScene
+from helios.scene import DynamicScene, StaticScene
 from helios.utils import (
     classonlymethod,
     get_asset_directories,
@@ -151,12 +151,12 @@ class PlatformSettings(PlatformSettingsBase):
     y: float = 0
     z: float = 0
 
-    def do_force_on_ground(self, scene: StaticScene):
+    def do_force_on_ground(self, scene: StaticScene | DynamicScene):
         """
         Move waypoint z coordinate to ground level
 
         :param scene: The scene to query for the ground level.
-        :type scene: StaticScene
+        :type scene: StaticScene | DynamicScene
         """
 
         ground_point = scene._cpp_object.ground_point_at((self.x, self.y, self.z))

--- a/python/helios/scene.py
+++ b/python/helios/scene.py
@@ -1002,7 +1002,32 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
             self._apply_material_to_all_primitives(material)
 
 
-class StaticScene(Model, cpp_class=_helios.StaticScene):
+class _Scene(Model, cpp_class=_helios.Scene):
+    """Private common wrapper for the polymorphic C++ scene hierarchy."""
+
+    def _set_reflectances(self, wavelength: float):
+        """Modify the scene's primitives with reflectances for a wavelength."""
+
+        _helios.set_scene_reflectances(
+            self._cpp_object, [str(p) for p in get_asset_directories()], wavelength
+        )
+
+    @classmethod
+    def _from_cpp(cls, value):
+        if isinstance(value, _helios.DynamicScene):
+            wrapper_class = DynamicScene
+        elif isinstance(value, _helios.StaticScene):
+            wrapper_class = StaticScene
+        else:
+            raise TypeError(
+                "Unsupported C++ scene type: "
+                f"{type(value).__name__}. Expected StaticScene or DynamicScene."
+            )
+
+        return Model._from_cpp.__func__(wrapper_class, value)
+
+
+class StaticScene(_Scene, cpp_class=_helios.StaticScene):
     """Class representing a static scene. A scene is composed of multiple scene parts, which can be transformed independently and have different materials.
 
     :param scene_parts: The scene parts that make up the scene.
@@ -1052,13 +1077,6 @@ class StaticScene(Model, cpp_class=_helios.StaticScene):
                 execution_settings.sah_nodes,
             )
 
-    def _set_reflectances(self, wavelength: float):
-        """Modify the scene's primitives with correct reflectances for the given wavelength."""
-
-        _helios.set_scene_reflectances(
-            self._cpp_object, [str(p) for p in get_asset_directories()], wavelength
-        )
-
     def _pre_set(self, field, value):
         if is_xml_loaded(self):
             raise RuntimeError("The scene loaded from XML cannot be modified.")
@@ -1086,6 +1104,11 @@ class StaticScene(Model, cpp_class=_helios.StaticScene):
             [str(p) for p in get_asset_directories()],
             True,
         )
+        if isinstance(_cpp_scene, _helios.DynamicScene):
+            raise TypeError(
+                "StaticScene.from_xml() cannot load a dynamic scene; use "
+                "DynamicScene.from_xml() instead."
+            )
         scene = cls._from_cpp(_cpp_scene)
         scene._is_loaded_from_xml = True
         scene._disable_yaml_serialization_for_descendants()
@@ -1204,3 +1227,37 @@ class StaticScene(Model, cpp_class=_helios.StaticScene):
             plotter.show(resetcam=True, interactive=interactive)
 
         return plotter
+
+
+class DynamicScene(_Scene, cpp_class=_helios.DynamicScene):
+    """A dynamic scene loaded from an XML scene definition.
+
+    Dynamic behavior is defined entirely by the XML file and executed by the
+    C++ simulation. Dynamic scenes intentionally expose no scene-part mutation
+    API in the high-level Python interface.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        if kwargs.get("_cpp_object") is None:
+            raise TypeError(
+                "DynamicScene cannot be constructed directly; use "
+                "DynamicScene.from_xml(...)"
+            )
+        return super().__new__(cls, *args, **kwargs)
+
+    @classonlymethod
+    @validate_call
+    def from_xml(cls, scene_file: AssetPath):
+        """Load a dynamic scene from an XML file."""
+
+        validate_xml_file(scene_file, "xsd/scene.xsd")
+        _cpp_scene = _helios.read_dynamic_scene_from_xml(
+            str(scene_file),
+            [str(p) for p in get_asset_directories()],
+            True,
+        )
+        scene = cls._from_cpp(_cpp_scene)
+        scene._is_loaded_from_xml = True
+        scene._disable_yaml_serialization_for_descendants()
+        scene._set_constructor_provenance("from_xml", scene_file=scene_file)
+        return scene

--- a/python/helios/scene.py
+++ b/python/helios/scene.py
@@ -37,6 +37,7 @@ from pydantic import (
     NonNegativeInt,
     validate_call,
 )
+from enum import Enum, auto
 from pathlib import Path
 from typing import Literal, Optional, Union, Tuple, Any
 import numpy as np
@@ -1229,6 +1230,12 @@ class StaticScene(_Scene, cpp_class=_helios.StaticScene):
         return plotter
 
 
+class _PlaybackState(Enum):
+    FRESH = auto()
+    RUNNING = auto()
+    CONSUMED = auto()
+
+
 class DynamicScene(_Scene, cpp_class=_helios.DynamicScene):
     """A dynamic scene loaded from an XML scene definition.
 
@@ -1244,6 +1251,35 @@ class DynamicScene(_Scene, cpp_class=_helios.DynamicScene):
                 "DynamicScene.from_xml(...)"
             )
         return super().__new__(cls, *args, **kwargs)
+
+    def _playback_state(self) -> _PlaybackState:
+        """Return the runtime-only playback lifecycle state."""
+
+        return getattr(self, "_dynamic_playback_state", _PlaybackState.FRESH)
+
+    def _ensure_fresh_for_playback(self):
+        """Reject reuse before survey execution causes any side effects."""
+
+        state = self._playback_state()
+        if state is _PlaybackState.RUNNING:
+            raise RuntimeError("This DynamicScene is already running in a survey.")
+        if state is _PlaybackState.CONSUMED:
+            raise RuntimeError(
+                "This DynamicScene has already been used and cannot be run again. "
+                "Dynamic-scene reset support is planned but not yet available; "
+                "load a fresh DynamicScene from XML for another run."
+            )
+
+    def _claim_for_playback(self):
+        """Mark playback as running immediately before it is started."""
+
+        self._ensure_fresh_for_playback()
+        self._dynamic_playback_state = _PlaybackState.RUNNING
+
+    def _consume_after_playback(self):
+        """Permanently consume the scene after a playback start attempt."""
+
+        self._dynamic_playback_state = _PlaybackState.CONSUMED
 
     @classonlymethod
     @validate_call

--- a/python/helios/scene.py
+++ b/python/helios/scene.py
@@ -1245,6 +1245,10 @@ class DynamicScene(_Scene, cpp_class=_helios.DynamicScene):
     API in the high-level Python interface.
     """
 
+    # Dynamic geometry and runtime playback state must never be written through
+    # the generic binary bundle path. YAML stores only from_xml provenance.
+    _provenance_only_serialization = True
+
     def __new__(cls, *args, **kwargs):
         if kwargs.get("_cpp_object") is None:
             raise TypeError(

--- a/python/helios/scene.py
+++ b/python/helios/scene.py
@@ -42,6 +42,7 @@ from pathlib import Path
 from typing import Literal, Optional, Union, Tuple, Any
 import numpy as np
 import vedo
+import weakref
 
 import _helios
 
@@ -1257,6 +1258,25 @@ class DynamicScene(_Scene, cpp_class=_helios.DynamicScene):
 
         return getattr(self, "_dynamic_playback_state", _PlaybackState.FRESH)
 
+    def _claim_owner(self, survey):
+        """Claim this scene for one live high-level survey wrapper."""
+
+        owner_ref = getattr(self, "_dynamic_owner_ref", None)
+        owner = owner_ref() if owner_ref is not None else None
+        if owner is not None and owner is not survey:
+            raise ValueError(
+                "This DynamicScene is already owned by another Survey; "
+                "one DynamicScene instance cannot be shared between surveys."
+            )
+        self._dynamic_owner_ref = weakref.ref(survey)
+
+    def _release_owner(self, survey):
+        """Release this scene if ``survey`` is its current owner."""
+
+        owner_ref = getattr(self, "_dynamic_owner_ref", None)
+        if owner_ref is not None and owner_ref() is survey:
+            del self._dynamic_owner_ref
+
     def _ensure_fresh_for_playback(self):
         """Reject reuse before survey execution causes any side effects."""
 
@@ -1280,6 +1300,22 @@ class DynamicScene(_Scene, cpp_class=_helios.DynamicScene):
         """Permanently consume the scene after a playback start attempt."""
 
         self._dynamic_playback_state = _PlaybackState.CONSUMED
+
+    def clone(self):
+        """Reject cloning until the complete C++ dynamic graph is independent."""
+
+        raise NotImplementedError(
+            "Cloning DynamicScene is not supported; load a fresh "
+            "DynamicScene from XML instead."
+        )
+
+    def __deepcopy__(self, memo):
+        """Reject deep copying until dynamic-scene cloning is proven safe."""
+
+        raise NotImplementedError(
+            "Deep copying DynamicScene is not supported; load a fresh "
+            "DynamicScene from XML instead."
+        )
 
     @classonlymethod
     @validate_call

--- a/python/helios/serialization.py
+++ b/python/helios/serialization.py
@@ -104,7 +104,7 @@ def _normalize_provenance_value(value: Any):
     if isinstance(value, Path):
         path = value.expanduser()
         if not path.is_absolute():
-            return str(path)
+            return path.as_posix()
 
         asset_dirs = [
             Path(directory).expanduser().resolve()
@@ -123,18 +123,20 @@ def _normalize_provenance_value(value: Any):
                 relative_candidates,
                 key=lambda candidate: (len(candidate.parts), len(str(candidate))),
             )
-            return str(shortest)
+            return shortest.as_posix()
 
         if asset_dirs:
             try:
-                return os.path.relpath(resolved_path, start=asset_dirs[0])
+                return Path(
+                    os.path.relpath(resolved_path, start=asset_dirs[0])
+                ).as_posix()
             except ValueError:
-                return str(resolved_path)
+                return resolved_path.as_posix()
 
         try:
-            return os.path.relpath(resolved_path, start=Path.cwd())
+            return Path(os.path.relpath(resolved_path, start=Path.cwd())).as_posix()
         except ValueError:
-            return str(resolved_path)
+            return resolved_path.as_posix()
 
     if isinstance(value, Enum):
         return value.value

--- a/python/helios/serialization.py
+++ b/python/helios/serialization.py
@@ -814,6 +814,12 @@ def _build_model_document(
 ) -> dict[str, Any]:
     """Create the serialized document payload for one model."""
 
+    if context.binary and getattr(model, "_provenance_only_serialization", False):
+        raise NotImplementedError(
+            f"Binary serialization is not supported for {model.__class__.__name__}; "
+            "use a non-binary YAML bundle instead."
+        )
+
     binary_info = None
     include_fields = not _uses_from_binary_constructor_provenance(model)
     if context.binary and callable(getattr(model, "to_binary", None)):

--- a/python/helios/survey.py
+++ b/python/helios/survey.py
@@ -8,7 +8,7 @@ from helios.platforms import (
     _specify_platform_settings_type,
 )
 from helios.scanner import Scanner, ScannerSettings
-from helios.scene import StaticScene
+from helios.scene import DynamicScene, StaticScene, _Scene
 from helios.callbacks import (
     CPP_HOOK_END_OF_LEG_POLICY_MAP,
     CPP_HOOK_PAYLOAD_MAP,
@@ -107,7 +107,7 @@ class Survey(Model, cpp_class=_helios.Survey):
     :param full_waveform_settings: The settings for the full waveform recording. If none is specified, the default settings will be used.
     :type scanner: Scanner
     :type platform: Platform
-    :type scene: StaticScene
+    :type scene: StaticScene | DynamicScene
     :type legs: Tuple[Leg, ...]
     :type name: str
     :type gps_time: datetime
@@ -116,7 +116,7 @@ class Survey(Model, cpp_class=_helios.Survey):
 
     scanner: Scanner
     platform: Platform
-    scene: StaticScene
+    scene: _Scene
     legs: Tuple[Leg, ...] = ()
     name: str = ""
     gps_time: datetime = datetime.now(timezone.utc)
@@ -145,6 +145,10 @@ class Survey(Model, cpp_class=_helios.Survey):
         :type callbacks: Optional[Sequence[SurveyHook]]
         :type live: bool | LiveViewer
         """
+        scene = self.scene
+        if isinstance(scene, DynamicScene):
+            scene._ensure_fresh_for_playback()
+
         # TODO: Options that need to be incorporated:
         # * Logging options from execution_settings
         # Update the settings to use
@@ -162,10 +166,10 @@ class Survey(Model, cpp_class=_helios.Survey):
             raise ValueError(f"Unknown parameters: {', '.join(parameters)}")
 
         # Ensure that the scene has been finalized
-        if not (is_xml_loaded(self) or is_xml_loaded(self.scene)):
-            self.scene._finalize(execution_settings)
+        if isinstance(scene, StaticScene) and not is_xml_loaded(scene):
+            scene._finalize(execution_settings)
 
-        self.scene._set_reflectances(self.scanner._cpp_object.wavelength)
+        scene._set_reflectances(self.scanner._cpp_object.wavelength)
 
         # we need to add serial IDs to the legs for proper process of writing into the file
         for i, leg in enumerate(self.legs):
@@ -182,9 +186,10 @@ class Survey(Model, cpp_class=_helios.Survey):
         )
 
         # also, for proper writing into the file, we need to set IDs for the scene parts
-        for i, scene_part in enumerate(self.scene.scene_parts):
-            if scene_part.id is None:
-                scene_part.id = str(i)
+        if isinstance(scene, StaticScene):
+            for i, scene_part in enumerate(scene.scene_parts):
+                if scene_part.id is None:
+                    scene_part.id = str(i)
 
         if output_settings.format in (OutputFormat.NPY, OutputFormat.LASPY):
             las_output, zip_output, export_to_file = False, False, False
@@ -275,7 +280,14 @@ class Survey(Model, cpp_class=_helios.Survey):
         try:
             if live_session is not None:
                 live_session.start()
-            _start_playback_interruptible(playback)
+            if isinstance(scene, DynamicScene):
+                scene._claim_for_playback()
+                try:
+                    _start_playback_interruptible(playback)
+                finally:
+                    scene._consume_after_playback()
+            else:
+                _start_playback_interruptible(playback)
         finally:
             if progressbar_controller is not None:
                 progressbar_controller.close()

--- a/python/helios/survey.py
+++ b/python/helios/survey.py
@@ -54,6 +54,7 @@ import threading
 import numpy as np
 import tempfile
 import laspy
+import weakref
 
 import _helios
 
@@ -148,6 +149,11 @@ class Survey(Model, cpp_class=_helios.Survey):
         scene = self.scene
         if isinstance(scene, DynamicScene):
             scene._ensure_fresh_for_playback()
+            if live is True or isinstance(live, LiveViewer):
+                raise NotImplementedError(
+                    "Live viewing is not supported for DynamicScene because the "
+                    "viewer cannot update moving geometry yet."
+                )
 
         # TODO: Options that need to be incorporated:
         # * Logging options from execution_settings
@@ -441,4 +447,40 @@ class Survey(Model, cpp_class=_helios.Survey):
 
     def _pre_set(self, field, value):
         if field == "scanner":
-            self._enforce_uniqueness_across_instances(field, value)
+            owner_ref = getattr(value, "_survey_owner_ref", None)
+            owner = owner_ref() if owner_ref is not None else None
+            if owner is not None and owner is not self:
+                raise ValueError(f"Value {value} is already used by another instance")
+
+            old_scanner = getattr(self, "_scanner", None)
+            value._survey_owner_ref = weakref.ref(self)
+            if old_scanner is not None and old_scanner is not value:
+                old_owner_ref = getattr(old_scanner, "_survey_owner_ref", None)
+                if old_owner_ref is not None and old_owner_ref() is self:
+                    del old_scanner._survey_owner_ref
+
+        if field == "scene":
+            old_scene = getattr(self, "_scene", None)
+            if isinstance(value, DynamicScene):
+                value._claim_owner(self)
+            if isinstance(old_scene, DynamicScene) and old_scene is not value:
+                old_scene._release_owner(self)
+
+    def _ensure_clone_supported(self):
+        if isinstance(self.scene, DynamicScene):
+            raise NotImplementedError(
+                "Cloning a Survey with a DynamicScene is not supported; load a "
+                "fresh survey or scene from XML instead."
+            )
+
+    def clone(self):
+        """Create an independent copy when the survey has a static scene."""
+
+        self._ensure_clone_supported()
+        return super().clone()
+
+    def __deepcopy__(self, memo):
+        """Deep-copy a survey when its scene supports independent copying."""
+
+        self._ensure_clone_supported()
+        return super().__deepcopy__(memo)

--- a/src/assetloading/XmlSceneLoader.cpp
+++ b/src/assetloading/XmlSceneLoader.cpp
@@ -88,7 +88,15 @@ XmlSceneLoader::createSceneFromXml(tinyxml2::XMLElement* sceneNode,
     logging::ERR("Finalizing the scene failed.");
     throw HeliosException("Finalizing the scene failed.");
   }
-  scene->setKDGroveFactory(makeKDGroveFactory()); // Better after building
+  // Dynamic scenes rebuild their KD-trees repeatedly during playback. Use the
+  // cheap sequential factory for the whole scene until dynamic scenes expose
+  // their own configurable KD-tree policy.
+  if (dynScene) {
+    scene->setKDGroveFactory(
+      std::make_shared<KDGroveFactory>(KDTreeFactoryMaker::makeSimple()));
+  } else {
+    scene->setKDGroveFactory(makeKDGroveFactory()); // Better after building
+  }
 
   // Handle dynamic scene attributes
   if (dynScene) {

--- a/src/python/PyXMLReader.cpp
+++ b/src/python/PyXMLReader.cpp
@@ -1,3 +1,4 @@
+#include <HeliosException.h>
 #include <PyXMLReader.h>
 #include <SpectralLibrary.h>
 #include <XmlSurveyLoader.h>
@@ -85,6 +86,32 @@ readSceneFromXml(std::string filePath,
     }
   }
   return nullptr;
+}
+
+std::shared_ptr<DynScene>
+readDynamicSceneFromXml(std::string filePath,
+                        std::vector<std::string> assetsPath,
+                        bool buildKDGrove)
+{
+  std::shared_ptr<Scene> scene =
+    readSceneFromXml(filePath, assetsPath, buildKDGrove);
+  if (!scene) {
+    throw HeliosException(
+      "read_dynamic_scene_from_xml() failed to load a scene from XML file '" +
+      filePath + "'.");
+  }
+
+  std::shared_ptr<DynScene> dynamicScene =
+    std::dynamic_pointer_cast<DynScene>(scene);
+  if (!dynamicScene) {
+    throw HeliosException(
+      "read_dynamic_scene_from_xml() requires XML that produces a dynamic "
+      "scene, but '" +
+      filePath +
+      "' produced a static scene. Use read_scene_from_xml() instead.");
+  }
+
+  return dynamicScene;
 }
 
 std::shared_ptr<ScenePart>

--- a/src/python/PyXMLReader.h
+++ b/src/python/PyXMLReader.h
@@ -1,3 +1,4 @@
+#include <DynScene.h>
 #include <StaticScene.h>
 #include <Survey.h>
 
@@ -25,6 +26,11 @@ std::shared_ptr<Scene>
 readSceneFromXml(std::string filePath,
                  std::vector<std::string> assetsPath,
                  bool buildKDGrove = true);
+
+std::shared_ptr<DynScene>
+readDynamicSceneFromXml(std::string filePath,
+                        std::vector<std::string> assetsPath,
+                        bool buildKDGrove = true);
 
 std::shared_ptr<ScenePart>
 readScenePartFromXml(std::string filePath,

--- a/src/scanner/Scanner.cpp
+++ b/src/scanner/Scanner.cpp
@@ -362,7 +362,7 @@ Scanner::buildScanningPulseProcess(
 {
   if (parallelizationStrategy == 0) {
     spp = std::unique_ptr<ScanningPulseProcess>(new BuddingScanningPulseProcess(
-      getDetector(0)->scanner,
+      getDetector(0)->scanner.lock(),
       scene,
       dropper,
       *(std::static_pointer_cast<PulseThreadPool>(pool)),
@@ -377,7 +377,7 @@ Scanner::buildScanningPulseProcess(
   } else if (parallelizationStrategy == 1) {
     spp =
       std::unique_ptr<ScanningPulseProcess>(new WarehouseScanningPulseProcess(
-        getDetector(0)->scanner,
+        getDetector(0)->scanner.lock(),
         scene,
         dropper,
         *(std::static_pointer_cast<PulseWarehouseThreadPool>(pool)),

--- a/src/scanner/detector/AbstractDetector.cpp
+++ b/src/scanner/detector/AbstractDetector.cpp
@@ -7,7 +7,7 @@
 void
 AbstractDetector::_clone(std::shared_ptr<AbstractDetector> ad)
 {
-  ad->scanner = scanner; // Reference pointer => copy pointer, not object
+  ad->scanner = scanner; // Weak back-reference => copy pointer, not object
   ad->cfg_device_accuracy_m = cfg_device_accuracy_m;
   ad->cfg_device_rangeMin_m = cfg_device_rangeMin_m;
   ad->cfg_device_rangeMax_m = cfg_device_rangeMax_m;
@@ -24,7 +24,8 @@ AbstractDetector::shutdown()
   if (fms != nullptr) {
     fms->write.finishMeasurementWriter();
     fms->write.finishTrajectoryWriter();
-    if (scanner->isWriteWaveform())
+    auto owner = scanner.lock();
+    if (owner != nullptr && owner->isWriteWaveform())
       fms->write.finishFullWaveformWriter();
   }
 }
@@ -33,7 +34,8 @@ AbstractDetector::onLegComplete()
 {
   if (pcloudYielder != nullptr)
     pcloudYielder->yield();
-  if (fwfYielder != nullptr && scanner->isWriteWaveform())
+  auto owner = scanner.lock();
+  if (fwfYielder != nullptr && owner != nullptr && owner->isWriteWaveform())
     fwfYielder->yield();
 }
 
@@ -45,9 +47,10 @@ AbstractDetector::setFMS(std::shared_ptr<helios::filems::FMSFacade> fms)
   this->fms = fms;
   if (fms != nullptr) {
     pcloudYielder = std::make_shared<PointcloudYielder>(fms->write);
-    if (scanner->isWriteWaveform())
+    auto owner = scanner.lock();
+    if (owner != nullptr && owner->isWriteWaveform())
       fwfYielder = std::make_shared<FullWaveformYielder>(fms->write);
-    if (scanner->isWritePulse())
+    if (owner != nullptr && owner->isWritePulse())
       pulseRecordYielder = std::make_shared<PulseRecordYielder>(fms->write);
   }
 }

--- a/src/scanner/detector/AbstractDetector.h
+++ b/src/scanner/detector/AbstractDetector.h
@@ -28,7 +28,7 @@ public:
   /**
    * @brief Scanner which the detector belongs to
    */
-  std::shared_ptr<Scanner> scanner = nullptr;
+  std::weak_ptr<Scanner> scanner;
 
 protected:
   /**
@@ -84,7 +84,7 @@ public:
     this->cfg_device_accuracy_m = accuracy_m;
     this->cfg_device_rangeMin_m = rangeMin_m;
     this->cfg_device_rangeMax_m = rangeMax_m;
-    this->scanner = std::move(scanner);
+    this->scanner = scanner;
     this->errorDistanceExpr = errorDistanceExpr;
   }
   virtual ~AbstractDetector() {}

--- a/src/scanner/detector/FullWaveformPulseDetector.cpp
+++ b/src/scanner/detector/FullWaveformPulseDetector.cpp
@@ -14,7 +14,7 @@ FullWaveformPulseDetector::clone()
 {
   std::shared_ptr<AbstractDetector> fwpd =
     std::make_shared<FullWaveformPulseDetector>(
-      scanner, cfg_device_accuracy_m, cfg_device_rangeMin_m);
+      scanner.lock(), cfg_device_accuracy_m, cfg_device_rangeMin_m);
   _clone(fwpd);
   return fwpd;
 }
@@ -38,6 +38,7 @@ void
 FullWaveformPulseDetector::shutdown()
 {
   AbstractDetector::shutdown();
-  if (fms != nullptr && scanner->isWriteWaveform())
+  auto owner = scanner.lock();
+  if (fms != nullptr && owner != nullptr && owner->isWriteWaveform())
     fms->write.finishFullWaveformWriter();
 }

--- a/src/sim/comps/Survey.h
+++ b/src/sim/comps/Survey.h
@@ -59,11 +59,7 @@ public:
    */
   Survey() = default;
   Survey(Survey& survey, bool const deepCopy = false);
-  ~Survey() override
-  {
-    if (scanner != nullptr)
-      scanner->setAllDetectors(nullptr);
-  }
+  ~Survey() override = default;
 
   // ***  M E T H O D S  *** //
   // *********************** //

--- a/src/test/AssetLoadingTest.cpp
+++ b/src/test/AssetLoadingTest.cpp
@@ -11,6 +11,10 @@ bool logging::LOGGING_SHOW_TRACE, logging::LOGGING_SHOW_DEBUG,
   logging::LOGGING_SHOW_INFO, logging::LOGGING_SHOW_TIME,
   logging::LOGGING_SHOW_WARN, logging::LOGGING_SHOW_ERR;
 
+#include <FastSAHKDTreeFactory.h>
+#include <KDGroveFactory.h>
+#include <MultiThreadKDTreeFactory.h>
+#include <SimpleKDTreeFactory.h>
 #include <WavefrontObjFileLoader.h>
 #include <assetloading/XmlAssetsLoader.h>
 #include <assetloading/XmlSceneLoader.h>
@@ -33,6 +37,33 @@ bool logging::LOGGING_SHOW_TRACE, logging::LOGGING_SHOW_DEBUG,
 TEST_CASE("Asset Loading Tests")
 {
   double const eps = 0.00001;
+
+  SECTION("Dynamic scenes default to a sequential Simple KD-tree")
+  {
+    std::filesystem::path const scenePath = "data/test/dynamic_scene.xml";
+    tinyxml2::XMLDocument doc;
+    REQUIRE(doc.LoadFile(scenePath.string().c_str()) == tinyxml2::XML_SUCCESS);
+
+    tinyxml2::XMLElement* sceneNode =
+      doc.FirstChildElement("document")->FirstChildElement("scene");
+    REQUIRE(sceneNode != nullptr);
+
+    XmlSceneLoader loader({ std::filesystem::current_path().string() });
+    loader.kdtFactoryType = 4;
+    loader.kdtNumJobs = 2;
+    loader.kdtGeomJobs = 1;
+    loader.kdtSAHLossNodes = 32;
+
+    std::shared_ptr<Scene> scene =
+      loader.createSceneFromXml(sceneNode, scenePath.string());
+    REQUIRE(std::dynamic_pointer_cast<DynScene>(scene) != nullptr);
+
+    std::shared_ptr<KDTreeFactory> factory =
+      scene->getKDGroveFactory()->getKdtf();
+    REQUIRE(dynamic_cast<SimpleKDTreeFactory*>(factory.get()) != nullptr);
+    REQUIRE(dynamic_cast<FastSAHKDTreeFactory*>(factory.get()) == nullptr);
+    REQUIRE(dynamic_cast<MultiThreadKDTreeFactory*>(factory.get()) == nullptr);
+  }
 
   SECTION("Test Scanner Loading")
   {

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -8,10 +8,11 @@ from helios.scanner import (
     riegl_vz_400,
     vlp16,
 )
-from helios.scene import ScenePart, StaticScene
+from helios.scene import DynamicScene, ScenePart, StaticScene
 from helios.settings import (
     ExecutionSettings,
     OutputSettings,
+    ProgressBarStrategy,
     set_execution_settings,
     set_output_settings,
 )
@@ -129,6 +130,73 @@ def tls_survey(tls_scanner, tripod, scene):
 
 
 survey = tls_survey
+
+
+@pytest.fixture
+def dynamic_test_execution_settings():
+    return ExecutionSettings(
+        num_threads=1,
+        kdt_num_threads=1,
+        kdt_geom_num_threads=1,
+        progressbar=ProgressBarStrategy.NONE,
+    )
+
+
+@pytest.fixture
+def dynamic_test_scene():
+    return DynamicScene.from_xml("data/test/dynamic_scene.xml")
+
+
+@pytest.fixture
+def dynamic_test_static_control_scene():
+    return StaticScene.from_xml("data/test/dynamic_scene_static_control.xml")
+
+
+@pytest.fixture
+def dynamic_test_survey_f():
+    def create(scene):
+        survey = Survey(scanner=riegl_vz_400(), platform=tripod_platform(), scene=scene)
+        survey.add_leg(
+            x=-30,
+            y=-30,
+            z=0,
+            force_on_ground=True,
+            pulse_frequency=5000,
+            min_vertical_angle="-40 deg",
+            max_vertical_angle="60 deg",
+            scan_frequency=120,
+            head_rotation="-60 deg/s",
+            rotation_start_angle="340 deg",
+            rotation_stop_angle="280 deg",
+        )
+        return survey
+
+    return create
+
+
+@pytest.fixture
+def manual_dynamic_test_survey(dynamic_test_survey_f, dynamic_test_scene):
+    return dynamic_test_survey_f(dynamic_test_scene)
+
+
+@pytest.fixture
+def xml_dynamic_test_survey():
+    return Survey.from_xml("data/test/dynamic_survey.xml")
+
+
+@pytest.fixture
+def dynamic_test_static_control_survey(
+    dynamic_test_survey_f, dynamic_test_static_control_scene
+):
+    return dynamic_test_survey_f(dynamic_test_static_control_scene)
+
+
+@pytest.fixture(
+    params=("manual_dynamic_test_survey", "xml_dynamic_test_survey"),
+    ids=("dynamic-scene-from-xml", "survey-from-xml"),
+)
+def dynamic_test_survey(request):
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture

--- a/tests/python/test_bindings.py
+++ b/tests/python/test_bindings.py
@@ -5,6 +5,44 @@ import threading
 from unittest.mock import MagicMock, patch
 import pytest
 
+STATIC_SCENE_XML = "data/scenes/demo/box_scene.xml"
+DYNAMIC_SCENE_XML = "data/scenes/dyn/dyn_cube_scene.xml"
+
+
+def test_xml_scene_loader_preserves_runtime_scene_type():
+    static_scene = _helios.read_scene_from_xml(STATIC_SCENE_XML, ["."], False)
+    dynamic_scene = _helios.read_scene_from_xml(DYNAMIC_SCENE_XML, ["."], False)
+
+    assert type(static_scene) is _helios.StaticScene
+    assert type(dynamic_scene) is _helios.DynamicScene
+
+
+def test_checked_dynamic_scene_loader_accepts_dynamic_xml():
+    scene = _helios.read_dynamic_scene_from_xml(
+        file_path=DYNAMIC_SCENE_XML,
+        assets_path=["."],
+        build_kd_grove=False,
+    )
+
+    assert type(scene) is _helios.DynamicScene
+
+
+def test_checked_dynamic_scene_loader_rejects_static_xml():
+    with pytest.raises(_helios.HeliosException, match="produced a static scene"):
+        _helios.read_dynamic_scene_from_xml(STATIC_SCENE_XML, ["."], False)
+
+
+def test_checked_dynamic_scene_loader_rejects_null_result(tmp_path):
+    missing_scene = tmp_path / "missing.xml"
+
+    with pytest.raises(_helios.HeliosException, match="failed to load a scene"):
+        _helios.read_dynamic_scene_from_xml(str(missing_scene), ["."], False)
+
+
+def test_dynamic_scene_has_no_public_constructor():
+    with pytest.raises(TypeError):
+        _helios.DynamicScene()
+
 
 def tuple_to_dvec3(t):
     return _helios.dvec3(*t)

--- a/tests/python/test_live.py
+++ b/tests/python/test_live.py
@@ -10,7 +10,7 @@ import pytest
 
 from helios.settings import OutputFormat
 from helios.utils import extract_position, meas_dtype, traj_dtype, _color_from_int
-from helios.scene import StaticScene, ScenePart
+from helios.scene import DynamicScene, StaticScene, ScenePart
 import inspect
 
 
@@ -264,6 +264,17 @@ def test_live_viewer_attach_to_survey_sets_scene_once(monkeypatch):
     assert viewer.scene == "scene-1"
     with pytest.raises(RuntimeError, match="attach_to_survey already called"):
         viewer.attach_to_survey(survey2)
+
+
+def test_live_viewer_rejects_dynamic_scene_attachment(monkeypatch):
+    live_module, _, _ = _import_modules_with_fake_vedo(monkeypatch)
+    viewer = live_module.LiveViewer()
+    dynamic_scene = DynamicScene.from_xml("data/scenes/dyn/dyn_cube_scene.xml")
+
+    with pytest.raises(NotImplementedError, match="Live viewing.*DynamicScene"):
+        viewer.attach_to_survey(SimpleNamespace(scene=dynamic_scene))
+
+    assert viewer.scene is None
 
 
 def test_ensure_scene_actors_builds_static_scene(monkeypatch):

--- a/tests/python/test_scene.py
+++ b/tests/python/test_scene.py
@@ -196,6 +196,38 @@ def test_construct_scene_from_xml():
     assert len(scene.scene_parts) == 5
 
 
+def test_construct_dynamic_scene_from_xml():
+    from helios.utils import is_xml_loaded
+
+    scene = DynamicScene.from_xml("data/scenes/dyn/dyn_cube_scene.xml")
+
+    assert isinstance(scene, DynamicScene)
+    assert isinstance(scene._cpp_object, _helios.DynamicScene)
+    assert not isinstance(scene, StaticScene)
+    assert not hasattr(scene, "scene_parts")
+    assert is_xml_loaded(scene)
+    assert scene._provenance["constructor"]["method"] == "from_xml"
+
+
+def test_dynamic_scene_direct_construction_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=r"DynamicScene cannot be constructed directly; use "
+        r"DynamicScene\.from_xml\(\.\.\.\)",
+    ):
+        DynamicScene()
+
+
+def test_static_scene_loader_rejects_dynamic_xml():
+    with pytest.raises(TypeError, match=r"use DynamicScene\.from_xml\(\) instead"):
+        StaticScene.from_xml("data/scenes/dyn/dyn_cube_scene.xml")
+
+
+def test_dynamic_scene_loader_rejects_static_xml():
+    with pytest.raises(HeliosException, match="produced a static scene"):
+        DynamicScene.from_xml("data/scenes/demo/box_scene.xml")
+
+
 def test_construct_scene_part_from_xml():
     part = ScenePart.from_xml("data/scenes/toyblocks/toyblocks_scene.xml", id=0)
     assert len(part._cpp_object.primitives) > 0

--- a/tests/python/test_scene.py
+++ b/tests/python/test_scene.py
@@ -228,6 +228,15 @@ def test_dynamic_scene_loader_rejects_static_xml():
         DynamicScene.from_xml("data/scenes/demo/box_scene.xml")
 
 
+def test_dynamic_scene_clone_and_deepcopy_are_rejected():
+    scene = DynamicScene.from_xml("data/scenes/dyn/dyn_cube_scene.xml")
+
+    with pytest.raises(NotImplementedError, match="Cloning DynamicScene"):
+        scene.clone()
+    with pytest.raises(NotImplementedError, match="Deep copying DynamicScene"):
+        copy.deepcopy(scene)
+
+
 def test_construct_scene_part_from_xml():
     part = ScenePart.from_xml("data/scenes/toyblocks/toyblocks_scene.xml", id=0)
     assert len(part._cpp_object.primitives) > 0

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -11,8 +11,8 @@ import helios.serialization as serialization
 from helios.platforms import DynamicPlatformSettings, Platform, TrajectorySettings
 from helios.serialization import _MIGRATIONS, register_migration
 from helios.scanner import Scanner
-from helios.scene import ScenePart, StaticScene
-from helios.settings import ExecutionSettings, OutputFormat
+from helios.scene import DynamicScene, ScenePart, StaticScene
+from helios.settings import ExecutionSettings, OutputFormat, ProgressBarStrategy
 from helios.survey import Survey
 from helios.utils import add_asset_directory, get_asset_directories, set_rng_seed
 from helios.validation import Model
@@ -70,6 +70,27 @@ def _build_manual_survey() -> Survey:
 
 def _build_xml_survey() -> Survey:
     return Survey.from_xml("data/test/serialization_survey.xml")
+
+
+def _build_manual_dynamic_survey(scene: DynamicScene | None = None) -> Survey:
+    scanner = Scanner.from_xml("data/scanners_tls.xml", scanner_id="riegl_vz400")
+    platform = Platform.from_xml("data/platforms.xml", platform_id="tripod")
+    scene = scene or DynamicScene.from_xml("data/scenes/dyn/dyn_cube_scene.xml")
+    survey = Survey(scanner=scanner, platform=platform, scene=scene, name="dynamic")
+    survey.add_leg(
+        x=-30,
+        y=-30,
+        z=0,
+        force_on_ground=True,
+        pulse_frequency=100000,
+        scan_frequency=120,
+        head_rotation="-10 deg/s",
+        rotation_start_angle="340 deg",
+        rotation_stop_angle="339 deg",
+        min_vertical_angle="-40 deg",
+        max_vertical_angle="60 deg",
+    )
+    return survey
 
 
 def _run_survey_npy(survey: Survey):
@@ -623,6 +644,124 @@ def test_static_scene_yaml_roundtrip(tmp_path):
     scene._finalize()
     loaded._finalize()
     assert len(scene._cpp_object.primitives) == len(loaded._cpp_object.primitives)
+
+
+def test_dynamic_scene_yaml_roundtrip_replays_only_xml_provenance(tmp_path):
+    scene = DynamicScene.from_xml("data/scenes/dyn/dyn_cube_scene.xml")
+    scene._claim_for_playback()
+    scene._consume_after_playback()
+
+    yaml_path = scene.to_yaml(tmp_path / "dynamic_scene.yaml", shallow=False)
+    with yaml_path.open("r", encoding="utf-8") as handle:
+        document = yaml.safe_load(handle)
+
+    assert document["serialization_major_version"] == 0
+    assert document["serialization_minor_version"] == 0
+    assert document["model_class"] == "helios.scene.DynamicScene"
+    assert document["fields"] == {}
+    assert document["provenance"] == {
+        "constructor": {
+            "method": "from_xml",
+            "kwargs": {"scene_file": "data/scenes/dyn/dyn_cube_scene.xml"},
+        },
+        "operations": [],
+    }
+    assert "binary" not in document
+    assert "playback" not in str(document).lower()
+    assert "consumed" not in str(document).lower()
+
+    loaded = DynamicScene.from_yaml(yaml_path)
+    assert isinstance(loaded, DynamicScene)
+    assert loaded._playback_state().name == "FRESH"
+    assert loaded._cpp_object is not scene._cpp_object
+
+    survey = _build_manual_dynamic_survey(loaded)
+    points, trajectory = survey.run(
+        format=OutputFormat.NPY,
+        execution_settings=ExecutionSettings(
+            num_threads=1, progressbar=ProgressBarStrategy.NONE
+        ),
+    )
+    assert points.shape[0] > 0
+    assert trajectory.shape[0] > 0
+
+
+@pytest.mark.parametrize("shallow", [False, True])
+def test_manual_dynamic_survey_yaml_roundtrip(tmp_path, shallow: bool):
+    survey = _build_manual_dynamic_survey()
+    yaml_path = survey.to_yaml(
+        tmp_path / f"dynamic_survey_{shallow}.yaml", shallow=shallow
+    )
+
+    with yaml_path.open("r", encoding="utf-8") as handle:
+        survey_document = yaml.safe_load(handle)
+    serialized_scene = survey_document["fields"]["scene"]
+    if shallow:
+        scene_yaml = tmp_path / serialized_scene["model_ref"]
+        with scene_yaml.open("r", encoding="utf-8") as handle:
+            scene_document = yaml.safe_load(handle)
+    else:
+        scene_document = serialized_scene
+
+    assert scene_document["model_class"] == "helios.scene.DynamicScene"
+    assert scene_document["fields"] == {}
+    assert scene_document["provenance"]["constructor"]["method"] == "from_xml"
+    assert "binary" not in scene_document
+
+    loaded = Survey.from_yaml(yaml_path)
+    assert isinstance(loaded.scene, DynamicScene)
+    assert loaded.scene._playback_state().name == "FRESH"
+    assert loaded.scene._cpp_object is not survey.scene._cpp_object
+
+
+def test_dynamic_xml_survey_yaml_uses_root_provenance(tmp_path):
+    survey = Survey.from_xml("data/surveys/dyn/tls_dyn_cube.xml")
+    yaml_path = survey.to_yaml(tmp_path / "dynamic_xml_survey.yaml", shallow=True)
+
+    with yaml_path.open("r", encoding="utf-8") as handle:
+        document = yaml.safe_load(handle)
+    assert document["model_class"] == "helios.survey.Survey"
+    assert document["provenance"]["constructor"] == {
+        "method": "from_xml",
+        "kwargs": {"survey_file": "data/surveys/dyn/tls_dyn_cube.xml"},
+    }
+
+    loaded = Survey.from_yaml(yaml_path)
+    assert isinstance(loaded.scene, DynamicScene)
+    assert loaded.scene._playback_state().name == "FRESH"
+    assert loaded.scene._yaml_serializable is False
+    with pytest.raises(RuntimeError, match="implicitly constructed"):
+        loaded.scene.to_yaml(tmp_path / "implicit_dynamic_scene.yaml")
+
+
+def test_dynamic_scene_non_binary_bundle_roundtrip(tmp_path):
+    scene = DynamicScene.from_xml("data/scenes/dyn/dyn_cube_scene.xml")
+    bundle_dir = tmp_path / "dynamic_scene_bundle"
+    root_yaml = scene.to_bundle(bundle_dir, binary=False)
+
+    with root_yaml.open("r", encoding="utf-8") as handle:
+        document = yaml.safe_load(handle)
+    bundled_scene_file = document["provenance"]["constructor"]["kwargs"]["scene_file"]
+    assert bundled_scene_file == "dyn_cube_scene.xml"
+    assert (bundle_dir / bundled_scene_file).exists()
+    assert "binary" not in document
+
+    loaded = DynamicScene.from_bundle(bundle_dir)
+    assert isinstance(loaded, DynamicScene)
+    assert loaded._playback_state().name == "FRESH"
+
+
+def test_dynamic_scene_binary_serialization_is_unavailable(tmp_path):
+    scene = DynamicScene.from_xml("data/scenes/dyn/dyn_cube_scene.xml")
+    assert not hasattr(scene, "to_binary")
+    assert not hasattr(DynamicScene, "from_binary")
+
+    with pytest.raises(NotImplementedError, match="Binary serialization.*DynamicScene"):
+        scene.to_bundle(tmp_path / "dynamic_binary_bundle", binary=True)
+
+    survey = _build_manual_dynamic_survey()
+    with pytest.raises(NotImplementedError, match="Binary serialization.*DynamicScene"):
+        survey.to_bundle(tmp_path / "dynamic_survey_binary_bundle", binary=True)
 
 
 def test_from_binary_to_yaml_uses_provenance_reference(tmp_path):

--- a/tests/python/test_survey.py
+++ b/tests/python/test_survey.py
@@ -18,6 +18,7 @@ from helios import HeliosException
 import copy
 import gc
 import laspy
+import numpy as np
 from numpy.lib.recfunctions import unstructured_to_structured
 import pytest
 import weakref
@@ -33,10 +34,8 @@ def test_construct_survey_from_xml():
     assert isinstance(survey.scene, StaticScene)
 
 
-def test_construct_dynamic_survey_from_xml():
-    dynamic_survey = Survey.from_xml("data/surveys/dyn/tls_dyn_cube.xml")
-
-    assert isinstance(dynamic_survey.scene, DynamicScene)
+def test_construct_dynamic_survey_from_xml(xml_dynamic_test_survey):
+    assert isinstance(xml_dynamic_test_survey.scene, DynamicScene)
 
 
 def test_dynamic_survey_is_one_shot(monkeypatch):
@@ -96,39 +95,72 @@ def test_pre_playback_validation_error_does_not_consume_dynamic_scene(monkeypatc
     assert len(starts) == 1
 
 
-def test_programmatically_composed_dynamic_survey_runs_once():
-    dynamic_scene = DynamicScene.from_xml("data/scenes/dyn/dyn_cube_scene.xml")
-    dynamic_survey = Survey(
-        scanner=riegl_vz_400(), platform=tripod(), scene=dynamic_scene
-    )
-    dynamic_survey.add_leg(
-        x=-30,
-        y=-30,
-        z=0,
-        force_on_ground=True,
-        pulse_frequency=100000,
-        scan_frequency=120,
-        head_rotation="-10 deg/s",
-        rotation_start_angle="340 deg",
-        rotation_stop_angle="339 deg",
-        min_vertical_angle="-40 deg",
-        max_vertical_angle="60 deg",
-    )
-    execution_settings = ExecutionSettings(
-        num_threads=1, progressbar=ProgressBarStrategy.NONE
+def test_dynamic_survey_moves_scene_and_callbacks_preserve_one_shot(
+    dynamic_test_survey,
+    dynamic_test_static_control_survey,
+    dynamic_test_execution_settings,
+):
+    callback_times = []
+
+    def record_time(context, points=None, trajectories=None):
+        callback_times.append(context.sim_time_s)
+
+    set_rng_seed(42)
+    points, _ = dynamic_test_survey.run(
+        format=OutputFormat.NPY,
+        execution_settings=dynamic_test_execution_settings,
+        callbacks=(
+            helios.SurveyHook(
+                point=helios.HookPoint.SIM_TIME_PERIODIC,
+                callback=record_time,
+                sim_time=0,
+                period=0.2,
+            ),
+        ),
     )
 
-    points, trajectory = dynamic_survey.run(
-        format=OutputFormat.NPY, execution_settings=execution_settings
+    set_rng_seed(42)
+    static_points, _ = dynamic_test_static_control_survey.run(
+        format=OutputFormat.NPY,
+        execution_settings=dynamic_test_execution_settings,
     )
 
     assert points.shape[0] > 0
-    assert trajectory.shape[0] > 0
     assert points.dtype["hit_object_id"].kind in ("i", "u")
+    assert 2 in points["hit_object_id"]
+    assert callback_times == sorted(callback_times)
+    assert len(callback_times) >= 2
+
+    dynamic_cube = points[points["hit_object_id"] == 2]
+    static_cube = static_points[static_points["hit_object_id"] == 2]
+    assert dynamic_cube.shape[0] > 0
+    assert static_cube.shape[0] > 0
+    assert (
+        dynamic_cube["position"][:, 0].mean() > static_cube["position"][:, 0].mean() + 4
+    )
+
     with pytest.raises(RuntimeError, match="reset support is planned"):
-        dynamic_survey.run(
-            format=OutputFormat.NPY, execution_settings=execution_settings
+        dynamic_test_survey.run(
+            format=OutputFormat.NPY,
+            execution_settings=dynamic_test_execution_settings,
         )
+
+
+def test_dynamic_survey_las_output_accepts_numeric_dynamic_object_id(
+    tmp_path, xml_dynamic_test_survey, dynamic_test_execution_settings
+):
+    output_path = xml_dynamic_test_survey.run(
+        format=OutputFormat.LAS,
+        output_dir=tmp_path,
+        execution_settings=dynamic_test_execution_settings,
+    )
+
+    files = list(output_path.rglob("*.las"))
+    assert len(files) == 1
+    las = laspy.read(files[0])
+    assert len(las.points) > 0
+    assert las.hitObjectId.dtype.kind in ("i", "u")
+    assert 2 in las.hitObjectId
 
 
 def test_dynamic_scene_cannot_be_shared_between_surveys():

--- a/tests/python/test_survey.py
+++ b/tests/python/test_survey.py
@@ -9,10 +9,10 @@ from helios.platforms import (
     StaticPlatformSettings,
 )
 from helios.scanner import Scanner, riegl_lms_q560, riegl_vz_1000, riegl_vz_400
-from helios.scene import StaticScene, ScenePart
+from helios.scene import DynamicScene, StaticScene, ScenePart
 from helios.settings import ExecutionSettings, OutputFormat, ProgressBarStrategy
 from helios.survey import *
-from helios.utils import set_rng_seed
+from helios.utils import meas_dtype, set_rng_seed, traj_dtype
 from helios import HeliosException
 
 import copy
@@ -29,6 +29,104 @@ def test_construct_survey_from_xml():
     assert isinstance(survey.platform, Platform)
     assert isinstance(survey.scanner, Scanner)
     assert isinstance(survey.scene, StaticScene)
+
+
+def test_construct_dynamic_survey_from_xml():
+    dynamic_survey = Survey.from_xml("data/surveys/dyn/tls_dyn_cube.xml")
+
+    assert isinstance(dynamic_survey.scene, DynamicScene)
+
+
+def test_dynamic_survey_is_one_shot(monkeypatch):
+    dynamic_survey = Survey.from_xml("data/surveys/dyn/tls_dyn_cube.xml")
+    starts = []
+
+    def record_start(playback):
+        starts.append(playback)
+        dynamic_survey.scanner._cpp_object.all_measurements = np.zeros(
+            (1,), dtype=meas_dtype
+        )
+        dynamic_survey.scanner._cpp_object.all_trajectories = np.zeros(
+            (1,), dtype=traj_dtype
+        )
+
+    monkeypatch.setattr(survey, "_start_playback_interruptible", record_start)
+    execution_settings = ExecutionSettings(
+        num_threads=1, progressbar=ProgressBarStrategy.NONE
+    )
+
+    dynamic_survey.run(format=OutputFormat.NPY, execution_settings=execution_settings)
+
+    assert len(starts) == 1
+    with pytest.raises(RuntimeError, match="reset support is planned"):
+        dynamic_survey.run(
+            format=OutputFormat.NPY, execution_settings=execution_settings
+        )
+    assert len(starts) == 1
+
+
+def test_pre_playback_validation_error_does_not_consume_dynamic_scene(monkeypatch):
+    dynamic_survey = Survey.from_xml("data/surveys/dyn/tls_dyn_cube.xml")
+    starts = []
+
+    def record_start(playback):
+        starts.append(playback)
+        dynamic_survey.scanner._cpp_object.all_measurements = np.zeros(
+            (1,), dtype=meas_dtype
+        )
+        dynamic_survey.scanner._cpp_object.all_trajectories = np.zeros(
+            (1,), dtype=traj_dtype
+        )
+
+    monkeypatch.setattr(survey, "_start_playback_interruptible", record_start)
+    execution_settings = ExecutionSettings(
+        num_threads=1, progressbar=ProgressBarStrategy.NONE
+    )
+
+    with pytest.raises(ValueError, match="Unknown parameters: unsupported_option"):
+        dynamic_survey.run(
+            format=OutputFormat.NPY,
+            execution_settings=execution_settings,
+            unsupported_option=True,
+        )
+
+    dynamic_survey.run(format=OutputFormat.NPY, execution_settings=execution_settings)
+    assert len(starts) == 1
+
+
+def test_programmatically_composed_dynamic_survey_runs_once():
+    dynamic_scene = DynamicScene.from_xml("data/scenes/dyn/dyn_cube_scene.xml")
+    dynamic_survey = Survey(
+        scanner=riegl_vz_400(), platform=tripod(), scene=dynamic_scene
+    )
+    dynamic_survey.add_leg(
+        x=-30,
+        y=-30,
+        z=0,
+        force_on_ground=True,
+        pulse_frequency=100000,
+        scan_frequency=120,
+        head_rotation="-10 deg/s",
+        rotation_start_angle="340 deg",
+        rotation_stop_angle="339 deg",
+        min_vertical_angle="-40 deg",
+        max_vertical_angle="60 deg",
+    )
+    execution_settings = ExecutionSettings(
+        num_threads=1, progressbar=ProgressBarStrategy.NONE
+    )
+
+    points, trajectory = dynamic_survey.run(
+        format=OutputFormat.NPY, execution_settings=execution_settings
+    )
+
+    assert points.shape[0] > 0
+    assert trajectory.shape[0] > 0
+    assert points.dtype["hit_object_id"].kind in ("i", "u")
+    with pytest.raises(RuntimeError, match="reset support is planned"):
+        dynamic_survey.run(
+            format=OutputFormat.NPY, execution_settings=execution_settings
+        )
 
 
 def test_leg_clone_and_deepcopy(survey):

--- a/tests/python/test_survey.py
+++ b/tests/python/test_survey.py
@@ -16,9 +16,11 @@ from helios.utils import meas_dtype, set_rng_seed, traj_dtype
 from helios import HeliosException
 
 import copy
+import gc
 import laspy
 from numpy.lib.recfunctions import unstructured_to_structured
 import pytest
+import weakref
 
 
 def test_construct_survey_from_xml():
@@ -127,6 +129,70 @@ def test_programmatically_composed_dynamic_survey_runs_once():
         dynamic_survey.run(
             format=OutputFormat.NPY, execution_settings=execution_settings
         )
+
+
+def test_dynamic_scene_cannot_be_shared_between_surveys():
+    dynamic_scene = DynamicScene.from_xml("data/scenes/dyn/dyn_cube_scene.xml")
+    owner = Survey(scanner=riegl_vz_400(), platform=tripod(), scene=dynamic_scene)
+
+    with pytest.raises(ValueError, match="already owned by another Survey"):
+        Survey(scanner=riegl_vz_400(), platform=tripod(), scene=dynamic_scene)
+
+    assert owner.scene is dynamic_scene
+
+
+def test_dynamic_scene_owner_is_released_on_reassignment():
+    first_scene = DynamicScene.from_xml("data/scenes/dyn/dyn_cube_scene.xml")
+    replacement_scene = DynamicScene.from_xml("data/scenes/dyn/dyn_cube_scene.xml")
+    first_owner = Survey(scanner=riegl_vz_400(), platform=tripod(), scene=first_scene)
+
+    first_owner.scene = replacement_scene
+    second_owner = Survey(scanner=riegl_vz_400(), platform=tripod(), scene=first_scene)
+
+    assert first_owner.scene is replacement_scene
+    assert second_owner.scene is first_scene
+
+
+def test_dynamic_scene_owner_is_released_after_garbage_collection():
+    dynamic_scene = DynamicScene.from_xml("data/scenes/dyn/dyn_cube_scene.xml")
+    owner = Survey(scanner=riegl_vz_400(), platform=tripod(), scene=dynamic_scene)
+    owner_ref = weakref.ref(owner)
+
+    del owner
+    gc.collect()
+
+    assert owner_ref() is None
+    replacement_owner = Survey(
+        scanner=riegl_vz_400(), platform=tripod(), scene=dynamic_scene
+    )
+    assert replacement_owner.scene is dynamic_scene
+
+
+def test_dynamic_survey_clone_and_deepcopy_are_rejected():
+    dynamic_survey = Survey.from_xml("data/surveys/dyn/tls_dyn_cube.xml")
+
+    with pytest.raises(NotImplementedError, match="Survey with a DynamicScene"):
+        dynamic_survey.clone()
+    with pytest.raises(NotImplementedError, match="Survey with a DynamicScene"):
+        copy.deepcopy(dynamic_survey)
+
+
+def test_dynamic_survey_rejects_live_viewing_before_attachment(monkeypatch):
+    dynamic_survey = Survey.from_xml("data/surveys/dyn/tls_dyn_cube.xml")
+
+    def unexpected_live_resolution(live):
+        raise AssertionError("live session resolution must not be reached")
+
+    monkeypatch.setattr(survey, "_resolve_live_session", unexpected_live_resolution)
+
+    with pytest.raises(NotImplementedError, match="Live viewing.*DynamicScene"):
+        dynamic_survey.run(live=True)
+
+    viewer = survey.LiveViewer.__new__(survey.LiveViewer)
+    with pytest.raises(NotImplementedError, match="Live viewing.*DynamicScene"):
+        dynamic_survey.run(live=viewer)
+
+    assert dynamic_survey.scene._playback_state().name == "FRESH"
 
 
 def test_leg_clone_and_deepcopy(survey):

--- a/tests/python/test_survey_interrupt.py
+++ b/tests/python/test_survey_interrupt.py
@@ -2,7 +2,9 @@ import threading
 
 import pytest
 
-from helios.survey import _start_playback_interruptible
+from helios import survey as survey_module
+from helios.settings import ExecutionSettings, OutputFormat, ProgressBarStrategy
+from helios.survey import Survey, _start_playback_interruptible
 
 
 def test_start_playback_interruptible_completes():
@@ -53,3 +55,28 @@ def test_start_playback_interruptible_stops_on_keyboard_interrupt(monkeypatch):
         _start_playback_interruptible(playback, poll_interval=0.001)
 
     assert playback.stop_calls == 1
+
+
+def test_interrupted_dynamic_survey_is_consumed(monkeypatch):
+    dynamic_survey = Survey.from_xml("data/surveys/dyn/tls_dyn_cube.xml")
+    starts = []
+
+    def interrupt_start(playback):
+        starts.append(playback)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(survey_module, "_start_playback_interruptible", interrupt_start)
+    execution_settings = ExecutionSettings(
+        num_threads=1, progressbar=ProgressBarStrategy.NONE
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        dynamic_survey.run(
+            format=OutputFormat.NPY, execution_settings=execution_settings
+        )
+
+    with pytest.raises(RuntimeError, match="reset support is planned"):
+        dynamic_survey.run(
+            format=OutputFormat.NPY, execution_settings=execution_settings
+        )
+    assert len(starts) == 1

--- a/tests/python/test_survey_interrupt.py
+++ b/tests/python/test_survey_interrupt.py
@@ -57,8 +57,8 @@ def test_start_playback_interruptible_stops_on_keyboard_interrupt(monkeypatch):
     assert playback.stop_calls == 1
 
 
-def test_interrupted_dynamic_survey_is_consumed(monkeypatch):
-    dynamic_survey = Survey.from_xml("data/surveys/dyn/tls_dyn_cube.xml")
+def test_interrupted_dynamic_survey_is_consumed(monkeypatch, xml_dynamic_test_survey):
+    dynamic_survey = xml_dynamic_test_survey
     starts = []
 
     def interrupt_start(playback):


### PR DESCRIPTION
This implements a minimal version of dynamic scene support: It is limited to legacy XML input (both on the scene level, or the survey level) and does not allow reuse of any scene for e.g. a second run. This intended as a step to allow us releasing v3 without introducing a major regression. The last WP of attached work plan was implemented with codex, but it is quite invasive into the C++ core and therefore quite hard to review, so I decided to not include it, as the risks IMO outweigh the benefits of being able to restart a simulation without reloading the scene.

Assisted by codex/GPT5.6 with this [work plan](https://github.com/user-attachments/files/30124880/plan.md)
