### PR TITLE
fix typo in original_bbox (prev. bbox_crs) in python

### DIFF
--- a/python/helios/live.py
+++ b/python/helios/live.py
@@ -261,7 +261,7 @@ class LiveViewer:
             return []
 
         actors: list[Any] = []
-        diff = self.scene.bbox_crs.centroid
+        diff = self.scene.original_bbox.centroid
         for part in self.scene.scene_parts:
             buffers = part._get_visualization_buffers(diff)
 

--- a/tests/python/test_live.py
+++ b/tests/python/test_live.py
@@ -271,7 +271,9 @@ def test_ensure_scene_actors_builds_static_scene(monkeypatch):
 
     viewer = live_module.LiveViewer()
     viewer.scene = SimpleNamespace(
-        bbox_crs=SimpleNamespace(centroid=np.array([0.0, 0.0, 0.0], dtype=np.float64)),
+        original_bbox=SimpleNamespace(
+            centroid=np.array([0.0, 0.0, 0.0], dtype=np.float64)
+        ),
         scene_parts=[
             SimpleNamespace(
                 _get_visualization_buffers=lambda diff: SimpleNamespace(
@@ -314,7 +316,9 @@ def test_create_scene_actors_returns_mesh_and_points(monkeypatch):
 
     viewer = live_module.LiveViewer()
     viewer.scene = SimpleNamespace(
-        bbox_crs=SimpleNamespace(centroid=np.array([0.0, 0.0, 0.0], dtype=np.float64)),
+        original_bbox=SimpleNamespace(
+            centroid=np.array([0.0, 0.0, 0.0], dtype=np.float64)
+        ),
         scene_parts=[
             SimpleNamespace(
                 _get_visualization_buffers=lambda diff: SimpleNamespace(


### PR DESCRIPTION
There was a leftover from the previous version of helios-live.

Thanks @han16nah  for finding this