### PR TITLE
fix setting/converting per-channel scan angle for PolygonMirrorBeamDeflector

### DIFF
--- a/src/assetloading/XmlAssetsLoader.cpp
+++ b/src/assetloading/XmlAssetsLoader.cpp
@@ -1451,7 +1451,8 @@ XmlAssetsLoader::fillScanningDevicesFromChannels(
         chan, "scanFreqMax_Hz", _deflec->cfg_device_scanFreqMax_Hz);
       if (XmlUtils::hasAttribute(chan, "scanAngleMax_deg")) {
         _deflec->cfg_device_scanAngleMax_rad =
-          XmlUtils::getAttributeCast<double>(chan, "scanAngleMax_deg", 0.0);
+          MathConverter::degreesToRadians(XmlUtils::getAttributeCast<double>(
+            chan, "scanAngleMax_deg", 0.0));
       }
       // Oscillating mirror beam deflector updates
       if (optics == "oscillating") {
@@ -1472,12 +1473,12 @@ XmlAssetsLoader::fillScanningDevicesFromChannels(
       if (optics == "rotating") {
         std::shared_ptr<PolygonMirrorBeamDeflector> pmbd =
           std::static_pointer_cast<PolygonMirrorBeamDeflector>(_deflec);
-        pmbd->cfg_device_scanAngleMax_rad =
+        pmbd->setScanAngleEffectiveMax_rad(
           MathConverter::degreesToRadians(XmlUtils::getAttributeCast<double>(
             chan,
             "scanAngleEffectiveMax_deg",
             MathConverter::radiansToDegrees(
-              pmbd->cfg_device_scanAngleMax_rad)));
+              pmbd->getScanAngleEffectiveMax_rad()))));
       }
       // Risley beam deflector updates
       if (optics == "risley") {

--- a/src/assetloading/XmlAssetsLoader.cpp
+++ b/src/assetloading/XmlAssetsLoader.cpp
@@ -1450,9 +1450,8 @@ XmlAssetsLoader::fillScanningDevicesFromChannels(
       _deflec->cfg_device_scanFreqMax_Hz = XmlUtils::getAttributeCast<double>(
         chan, "scanFreqMax_Hz", _deflec->cfg_device_scanFreqMax_Hz);
       if (XmlUtils::hasAttribute(chan, "scanAngleMax_deg")) {
-        _deflec->cfg_device_scanAngleMax_rad =
-          MathConverter::degreesToRadians(XmlUtils::getAttributeCast<double>(
-            chan, "scanAngleMax_deg", 0.0));
+        _deflec->cfg_device_scanAngleMax_rad = MathConverter::degreesToRadians(
+          XmlUtils::getAttributeCast<double>(chan, "scanAngleMax_deg", 0.0));
       }
       // Oscillating mirror beam deflector updates
       if (optics == "oscillating") {

--- a/src/scanner/beamDeflector/PolygonMirrorBeamDeflector.h
+++ b/src/scanner/beamDeflector/PolygonMirrorBeamDeflector.h
@@ -69,4 +69,12 @@ public:
   {
     return cfg_device_scanAngleEffectiveMax_rad;
   }
+  /**
+   * @brief Set the maximum effective scan angle in radians.
+   * @see PolygonMirrorBeamDeflector::cfg_device_scanAngleEffectiveMax_rad
+   */
+  void setScanAngleEffectiveMax_rad(double scanAngleEffectiveMax_rad)
+  {
+    cfg_device_scanAngleEffectiveMax_rad = scanAngleEffectiveMax_rad;
+  }
 };


### PR DESCRIPTION
- Fix 1: per-channel scanAngleMax is now properly converted from degrees to radians, which was missing before
- Fix 2: make sure that scanAngleEffectiveMax is correctly written to `cfg_device_scanAngleEffectiveMax_rad` instead of `cfg_device_scanAngleMax_rad`
  - added a `setScanAngleEffectiveMax_rad()` public setter alongside the existing getter, since `cfg_device_scanAngleEffectiveMax_rad` is protected