### PR TITLE
add hit object id to laspy output

### DIFF
--- a/python/helios/survey.py
+++ b/python/helios/survey.py
@@ -314,7 +314,7 @@ class Survey(Model, cpp_class=_helios.Survey):
                     [
                         laspy.ExtraBytesParams("echo_width", "f8"),
                         laspy.ExtraBytesParams("fullwaveIndex", "i4"),
-                        # laspy.ExtraBytesParams("hitObjectId", "U50"),
+                        laspy.ExtraBytesParams("hitObjectId", "i4"),
                     ]
                 )
                 header.generating_software = "HELIOS++"
@@ -332,7 +332,7 @@ class Survey(Model, cpp_class=_helios.Survey):
                 las.classification = measurements["classification"]
                 las.echo_width = measurements["echo_width"]
                 las.fullwaveIndex = measurements["fullwave_index"]
-                # las.hitObjectId = data_mes["hit_object_id"]
+                las.hitObjectId = measurements["hit_object_id"]
 
                 return las, trajectories
 

--- a/tests/python/test_survey.py
+++ b/tests/python/test_survey.py
@@ -405,7 +405,23 @@ def test_survey_run_las_output(survey, tmp_path):
 
     # Read the output
     las = laspy.read(files[0])
-    las.X.shape[0] == 352
+    assert las.X.shape[0] == 352
+    column_names = list(las.point_format.dimension_names)
+    names_to_check = [
+        "X",
+        "Y",
+        "Z",
+        "intensity",
+        "return_number",
+        "number_of_returns",
+        "gps_time",
+        "classification",
+        "echo_width",
+        "fullwaveIndex",
+        "hitObjectId",
+    ]
+    for name in names_to_check:
+        assert name in column_names
 
 
 def test_survey_run_laz_output(survey, tmp_path):
@@ -417,7 +433,7 @@ def test_survey_run_laz_output(survey, tmp_path):
 
     # Read the output
     las = laspy.read(files[0])
-    las.X.shape[0] == 200
+    assert las.X.shape[0] == 352
 
 
 def test_survey_run_xyz_output(survey, tmp_path):


### PR DESCRIPTION
Add hit object ID to laspy output
This has previously been commented out, likely because the hit object ID has not been been an integer back then (cf. #189 )