### PR TITLE
Voxel scale fix

### DIFF
--- a/python/helios/helios_python.cpp
+++ b/python/helios/helios_python.cpp
@@ -60,8 +60,8 @@ PYBIND11_MAKE_OPAQUE(std::vector<Trajectory>);
 #include <scene/primitives/DetailedVoxel.h>
 #include <scene/primitives/Primitive.h>
 #include <scene/primitives/Triangle.h>
-#include <scene/primitives/Voxel.h>
 #include <scene/primitives/Vertex.h>
+#include <scene/primitives/Voxel.h>
 #include <sim/core/SurveyHooks.h>
 
 #include <DynMovingObject.h>

--- a/python/helios/helios_python.cpp
+++ b/python/helios/helios_python.cpp
@@ -60,6 +60,7 @@ PYBIND11_MAKE_OPAQUE(std::vector<Trajectory>);
 #include <scene/primitives/DetailedVoxel.h>
 #include <scene/primitives/Primitive.h>
 #include <scene/primitives/Triangle.h>
+#include <scene/primitives/Voxel.h>
 #include <scene/primitives/Vertex.h>
 #include <sim/core/SurveyHooks.h>
 
@@ -434,7 +435,10 @@ PYBIND11_MODULE(_helios, m)
     .def_property_readonly("centroid", &AABB::getCentroid)
     .def("__str__", &AABB::toString);
 
-  py::class_<DetailedVoxel, std::shared_ptr<DetailedVoxel>, Primitive>
+  py::class_<Voxel, std::shared_ptr<Voxel>, Primitive> voxel(m, "Voxel");
+  voxel.def_readonly("half_size", &Voxel::halfSize);
+
+  py::class_<DetailedVoxel, std::shared_ptr<DetailedVoxel>, Voxel>
     detailed_voxel(m, "DetailedVoxel");
   detailed_voxel.def(py::init<>())
     .def(py::init<glm::dvec3, double, std::vector<int>, std::vector<double>>(),

--- a/src/assetloading/ScenePart.cpp
+++ b/src/assetloading/ScenePart.cpp
@@ -270,20 +270,12 @@ ScenePart::computeCentroid(bool const computeBound)
 }
 
 void
-ScenePart::computeTransformations(std::shared_ptr<ScenePart> sp,
-                                  bool const holistic)
+ScenePart::computeTransformations(std::shared_ptr<ScenePart> sp)
 {
   // For all primitives, set reference to their scene part and transform:
   for (Primitive* p : sp->mPrimitives) {
     p->part = sp;
     p->rotate(sp->mRotation);
-    if (holistic) {
-      for (size_t i = 0; i < p->getNumVertices(); i++) {
-        p->getVertices()[i].pos.x *= sp->mScale;
-        p->getVertices()[i].pos.y *= sp->mScale;
-        p->getVertices()[i].pos.z *= sp->mScale;
-      }
-    }
     p->scale(sp->mScale);
     p->translate(sp->mOrigin);
   }

--- a/src/assetloading/ScenePart.h
+++ b/src/assetloading/ScenePart.h
@@ -347,13 +347,10 @@ public:
    *  The transformations are typically specified through assetloading
    *  filters.
    * @param sp The ScenePart whose transformations must be computed.
-   * @param holistic Whether to use an holistic approach for all the vertices
-   *  (e.g., for points loaded from point clouds as input).
    * @see XmlSceneLoader
    * @see XmlSceneLoader::digestScenePart
    * @see SwapOnRepeatHandler
    * @see SimulationPlayer
    */
-  static void computeTransformations(std::shared_ptr<ScenePart> sp,
-                                     bool const holistic = false);
+  static void computeTransformations(std::shared_ptr<ScenePart> sp);
 };

--- a/src/assetloading/SwapOnRepeatHandler.cpp
+++ b/src/assetloading/SwapOnRepeatHandler.cpp
@@ -9,7 +9,6 @@
 SwapOnRepeatHandler::SwapOnRepeatHandler()
   : currentTimeToLive(1)
   , discardOnReplay(false)
-  , holistic(false)
   , onSwapFirstPlay(false)
   , keepCRS(true)
   , baseline(nullptr)
@@ -85,11 +84,6 @@ SwapOnRepeatHandler::doSwap(ScenePart& sp)
     ScenePart* genSP = filter->run();
     // Update the geometry if a new one has been loaded
     if (genSP != nullptr && genSP != std::addressof(sp)) {
-      // Make holistic only if geometry is derived from a point cloud
-      holistic = false;
-      if (dynamic_cast<XYZPointCloudFileLoader*>(filter) != nullptr) {
-        holistic = true;
-      }
       // Free primitives memory from scene part
       for (Primitive* p : sp.mPrimitives)
         delete p;

--- a/src/assetloading/SwapOnRepeatHandler.h
+++ b/src/assetloading/SwapOnRepeatHandler.h
@@ -51,11 +51,6 @@ protected:
    */
   bool discardOnReplay;
   /**
-   * @brief Whether all the vertices defining each primitive must be
-   *  considered as a whole.
-   */
-  bool holistic;
-  /**
    * @brief Whether the simulation is at the first play of the current
    *  swap.
    */
@@ -132,15 +127,6 @@ public:
   {
     return numCurrentSwaps < numTargetSwaps;
   }
-  /**
-   * @brief Check whether the handler needs an holistic approach (all the
-   *  vertices must be considered as a whole).
-   *
-   * Swap on repeat handlers are typically holistic if the geometry they
-   *  handle was loaded from a point cloud (see XYZPointCloudFileLoader).
-   * @return True if the handler needs an holistic approach, false otherwise.
-   */
-  inline bool isHolistic() const { return holistic; }
   /**
    * @brief Check whether the active swap of the handler is at its first
    *  play or not (when TTL>1, a swap will be active for more than one play).

--- a/src/assetloading/XmlSceneLoader.cpp
+++ b/src/assetloading/XmlSceneLoader.cpp
@@ -66,8 +66,7 @@ XmlSceneLoader::createSceneFromXml(tinyxml2::XMLElement* sceneNode,
     sceneSpec.apply(scenePart);
 
     // Digest scene part
-    digestScenePart(
-      scenePart, scene, splitPart, dynObject, partIndex);
+    digestScenePart(scenePart, scene, splitPart, dynObject, partIndex);
 
     // Read next scene part from XML
     scenePartNode = scenePartNode->NextSiblingElement("part");
@@ -116,8 +115,7 @@ XmlSceneLoader::loadFilters(tinyxml2::XMLElement* scenePartNode)
   while (filterNodes != nullptr) {
     // Load the filter
     std::string filterType = filterNodes->Attribute("type");
-    AbstractGeometryFilter* filter =
-      loadFilter(filterNodes, scenePart);
+    AbstractGeometryFilter* filter = loadFilter(filterNodes, scenePart);
     // Apply the filter
     if (filter != nullptr) {
       // Set params:
@@ -232,8 +230,7 @@ XmlSceneLoader::loadScenePartSwaps(tinyxml2::XMLElement* scenePartNode,
     } else {
       // Add non-null filters to the handler
       while (filterNodes != nullptr) {
-        AbstractGeometryFilter* filter =
-          loadFilter(filterNodes, scenePart);
+        AbstractGeometryFilter* filter = loadFilter(filterNodes, scenePart);
         filter->params = XmlUtils::createParamsFromXml(filterNodes);
         swapFilters.push_back(filter);
         // Find next XML filter element

--- a/src/assetloading/XmlSceneLoader.cpp
+++ b/src/assetloading/XmlSceneLoader.cpp
@@ -33,11 +33,10 @@ XmlSceneLoader::createSceneFromXml(tinyxml2::XMLElement* sceneNode,
   tw.start();
   while (scenePartNode != nullptr) {
     partIndex++;
-    bool holistic = false;
     bool dynObject = false;
 
     // Load filter nodes, if any
-    std::shared_ptr<ScenePart> scenePart = loadFilters(scenePartNode, holistic);
+    std::shared_ptr<ScenePart> scenePart = loadFilters(scenePartNode);
 
     // Read and set scene part ID
     bool splitPart = loadScenePartId(scenePartNode, partIndex, scenePart);
@@ -68,7 +67,7 @@ XmlSceneLoader::createSceneFromXml(tinyxml2::XMLElement* sceneNode,
 
     // Digest scene part
     digestScenePart(
-      scenePart, scene, holistic, splitPart, dynObject, partIndex);
+      scenePart, scene, splitPart, dynObject, partIndex);
 
     // Read next scene part from XML
     scenePartNode = scenePartNode->NextSiblingElement("part");
@@ -109,7 +108,7 @@ XmlSceneLoader::createSceneFromXml(tinyxml2::XMLElement* sceneNode,
 }
 
 std::shared_ptr<ScenePart>
-XmlSceneLoader::loadFilters(tinyxml2::XMLElement* scenePartNode, bool& holistic)
+XmlSceneLoader::loadFilters(tinyxml2::XMLElement* scenePartNode)
 {
   ScenePart* scenePart = nullptr;
   tinyxml2::XMLElement* filterNodes =
@@ -118,7 +117,7 @@ XmlSceneLoader::loadFilters(tinyxml2::XMLElement* scenePartNode, bool& holistic)
     // Load the filter
     std::string filterType = filterNodes->Attribute("type");
     AbstractGeometryFilter* filter =
-      loadFilter(filterNodes, holistic, scenePart);
+      loadFilter(filterNodes, scenePart);
     // Apply the filter
     if (filter != nullptr) {
       // Set params:
@@ -154,7 +153,6 @@ XmlSceneLoader::loadFilters(tinyxml2::XMLElement* scenePartNode, bool& holistic)
 
 AbstractGeometryFilter*
 XmlSceneLoader::loadFilter(tinyxml2::XMLElement* filterNode,
-                           bool& holistic,
                            ScenePart* scenePart)
 {
   std::string filterType = filterNode->Attribute("type");
@@ -193,7 +191,6 @@ XmlSceneLoader::loadFilter(tinyxml2::XMLElement* filterNode,
   // Read xyz ASCII point cloud file:
   else if (filterType == "xyzloader") {
     filter = new XYZPointCloudFileLoader();
-    holistic = true;
   }
 
   // Read detailed voxels file
@@ -220,7 +217,6 @@ XmlSceneLoader::loadScenePartSwaps(tinyxml2::XMLElement* scenePartNode,
   std::shared_ptr<SwapOnRepeatHandler> sorh =
     std::make_shared<SwapOnRepeatHandler>();
   while (swapNodes != nullptr) {
-    bool holistic = false;
     int const swapStep =
       XmlUtils::getAttributeCast<int>(swapNodes, "swapStep", 1);
     bool const keepCRS =
@@ -237,7 +233,7 @@ XmlSceneLoader::loadScenePartSwaps(tinyxml2::XMLElement* scenePartNode,
       // Add non-null filters to the handler
       while (filterNodes != nullptr) {
         AbstractGeometryFilter* filter =
-          loadFilter(filterNodes, holistic, scenePart);
+          loadFilter(filterNodes, scenePart);
         filter->params = XmlUtils::createParamsFromXml(filterNodes);
         swapFilters.push_back(filter);
         // Find next XML filter element
@@ -338,13 +334,12 @@ XmlSceneLoader::validateScenePart(std::shared_ptr<ScenePart> scenePart,
 void
 XmlSceneLoader::digestScenePart(std::shared_ptr<ScenePart>& scenePart,
                                 std::shared_ptr<StaticScene>& scene,
-                                bool holistic,
                                 bool splitPart,
                                 bool dynObject,
                                 int& partIndex)
 {
   // For all primitives, set reference to their scene part and transform:
-  ScenePart::computeTransformations(scenePart, holistic);
+  ScenePart::computeTransformations(scenePart);
 
   // Append as static object if it is not dynamic
   // If it is dynamic, it must have been appended before

--- a/src/assetloading/XmlSceneLoader.h
+++ b/src/assetloading/XmlSceneLoader.h
@@ -100,25 +100,19 @@ public:
    *  be instantiated, otherwise it will be nullptr
    *
    * @param scenePartNode XML part node defining the scene part
-   * @param[out] holistic Used to specify if all vertices defining each
-   *  primitive must be considered as a whole (true) or not
    * @return Built scene part if any, nullptr otherwise
    * @see XmlSceneLoader::loadfilter
    */
-  std::shared_ptr<ScenePart> loadFilters(tinyxml2::XMLElement* scenePartNode,
-                                         bool& holistic);
+  std::shared_ptr<ScenePart> loadFilters(tinyxml2::XMLElement* scenePartNode);
 
   /**
    * @brief Load a filter from a XML filter node.
    * @param filterNode XML node defining the filter.
-   * @param[out] holistic Used to specify if all vertices defining each
-   *  primitive must be considered as a whole (true) or not
    * @param scenePart The scene part to be transformed by the filter.
    * @return Built filter if any, nullptr otherwise
    * @see XmlSceneLoader::loadFilters
    */
   AbstractGeometryFilter* loadFilter(tinyxml2::XMLElement* filterNode,
-                                     bool& holistic,
                                      ScenePart* scenePart);
 
   /**
@@ -163,8 +157,6 @@ public:
    *  integrated in the scene and totally configured
    * @param scenePart The scene part object to be digested
    * @param scene The scene where the scene part belongs
-   * @param holistic Flag used to specify if all vertices defining each
-   *  primitive must be considered as a whole (true) or not (false)
    * @param splitPart Flag to specify if scene part must be splitted into
    *  subparts (true) or not (false)
    * @param dynObject Flag to specify if the scene part corresponds to a
@@ -175,7 +167,6 @@ public:
    */
   void digestScenePart(std::shared_ptr<ScenePart>& scenePart,
                        std::shared_ptr<StaticScene>& scene,
-                       bool holistic,
                        bool splitPart,
                        bool dynObject,
                        int& partIndex);

--- a/src/python/PyXMLReader.cpp
+++ b/src/python/PyXMLReader.cpp
@@ -177,8 +177,7 @@ readScenePartFromXml(std::string filePath,
   }
   XmlSceneLoader xmlSceneLoader(assetsPath);
 
-  std::shared_ptr<ScenePart> scenePart =
-    xmlSceneLoader.loadFilters(part);
+  std::shared_ptr<ScenePart> scenePart = xmlSceneLoader.loadFilters(part);
   scenePart->mId = finalId;
 
   // For all primitives, set reference to their scene part and transform:

--- a/src/python/PyXMLReader.cpp
+++ b/src/python/PyXMLReader.cpp
@@ -142,7 +142,6 @@ readScenePartFromXml(std::string filePath,
   int currentIndex = 0;
   std::string finalId = "";
   bool splitPart = true;
-  bool holistic = false;
 
   while (part) {
     const char* partId = part->Attribute("id");
@@ -179,11 +178,11 @@ readScenePartFromXml(std::string filePath,
   XmlSceneLoader xmlSceneLoader(assetsPath);
 
   std::shared_ptr<ScenePart> scenePart =
-    xmlSceneLoader.loadFilters(part, holistic);
+    xmlSceneLoader.loadFilters(part);
   scenePart->mId = finalId;
 
   // For all primitives, set reference to their scene part and transform:
-  ScenePart::computeTransformations(scenePart, holistic);
+  ScenePart::computeTransformations(scenePart);
 
   // Infer type of primitive for the scene part
   auto numVertices = scenePart->mPrimitives[0]->getNumVertices();

--- a/src/scene/primitives/Voxel.h
+++ b/src/scene/primitives/Voxel.h
@@ -218,6 +218,7 @@ public:
    */
   void scale(double const factor) override
   {
+    Primitive::scale(factor);
     halfSize *= factor;
     update();
   }

--- a/src/sim/comps/SimulationPlayer.cpp
+++ b/src/sim/comps/SimulationPlayer.cpp
@@ -212,7 +212,7 @@ SimulationPlayer::restartScene(Scene& scene, bool const keepCRS)
     }
     // Handle scene parts who are in the first play after a swap
     if (sp->sorh != nullptr && sp->sorh->isOnSwapFirstPlay()) {
-      ScenePart::computeTransformations(sp, sp->sorh->isHolistic());
+      ScenePart::computeTransformations(sp);
       sp->sorh->setOnSwapFirstPlay(false);
       if (!sp->mPrimitives.empty()) {
         sp->sorh->setNull(false);

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -88,6 +88,16 @@ def box(box_f):
 
 
 @pytest.fixture
+def vox_f():
+    return lambda: ScenePart.from_vox("data/sceneparts/syssifoss/F_BR08_08_merged.vox")
+
+
+@pytest.fixture
+def vox(vox_f):
+    return vox_f()
+
+
+@pytest.fixture
 def wall_f():
     return (
         lambda: ScenePart.from_obj("data/sceneparts/basic/plane/plane.obj")

--- a/tests/python/test_scene.py
+++ b/tests/python/test_scene.py
@@ -98,6 +98,11 @@ def xyz_file(tmp_path) -> Path:
 
 
 @pytest.fixture
+def xyz_scenepart_f(xyz_file):
+    return lambda: ScenePart.from_xyz(str(xyz_file), separator=" ", voxel_size=1.0)
+
+
+@pytest.fixture
 def only_points_xyz_file(tmp_path) -> Path:
     path = tmp_path / "small_only_points.xyz"
     _write_only_points_xyz_file(path)
@@ -648,7 +653,7 @@ def test_rotate_scenepart_rotation_center(box_f):
     assert np.allclose(bbox1, bbox2)
 
 
-def test_scale_scenepart(box_f):
+def test_scale_mesh_scenepart(box_f):
     box1 = box_f()
     box2 = box_f()
 
@@ -661,9 +666,33 @@ def test_scale_scenepart(box_f):
     assert np.allclose(bbox1 * scale, bbox2)
 
 
-def test_voxel_scenepart():
-    # to add
-    pass
+@pytest.mark.parametrize("factory_fixture,scale", 
+                         [("xyz_scenepart_f", 2.0),
+                          ("xyz_scenepart_f", 0.5),
+                          ("vox_f", 2.0),
+                          ("vox_f", 0.5)])
+def test_scale_voxelized_scenepart(factory_fixture, scale, request):
+    factory = request.getfixturevalue(factory_fixture)
+    vox1 = factory()
+    vox2 = factory()
+
+    vox2.scale(scale)
+
+    bbox1 = np.array(vox1.bbox.bounds)
+    bbox2 = np.array(vox2.bbox.bounds)
+    assert np.allclose(bbox1 * scale, bbox2)
+
+    half_size1 = np.array(
+        [p.half_size for p in vox1._cpp_object.primitives]
+    )
+    half_size2 = np.array(
+        [p.half_size for p in vox2._cpp_object.primitives]
+    )
+    assert np.allclose(half_size1 * scale, half_size2)
+
+    ratio1 = (bbox1[1] - bbox1[0]) / half_size1[0]
+    ratio2 = (bbox2[1] - bbox2[0]) / half_size2[0]
+    assert np.allclose(ratio1, ratio2)
 
 
 def test_transform_scenepart(box_f):

--- a/tests/python/test_scene.py
+++ b/tests/python/test_scene.py
@@ -642,8 +642,8 @@ def test_rotate_scenepart_rotation_center(box_f):
 
     box1.rotate(angle="180 deg", axis=[0, 0, 1.0], rotation_center=[100.0, 0.0, 0.0])
     box2.translate([200.0, 0.0, 0.0])
-    bbox1 =  np.array(box1.bbox.bounds)
-    bbox2 =  np.array(box2.bbox.bounds)
+    bbox1 = np.array(box1.bbox.bounds)
+    bbox2 = np.array(box2.bbox.bounds)
 
     assert np.allclose(bbox1, bbox2)
 

--- a/tests/python/test_scene.py
+++ b/tests/python/test_scene.py
@@ -661,6 +661,11 @@ def test_scale_scenepart(box_f):
     assert np.allclose(bbox1 * scale, bbox2)
 
 
+def test_voxel_scenepart():
+    # to add
+    pass
+
+
 def test_transform_scenepart(box_f):
     box1 = box_f()
     box2 = box_f()

--- a/tests/python/test_scene.py
+++ b/tests/python/test_scene.py
@@ -529,11 +529,6 @@ def test_scenepart_from_vox():
         )
 
 
-def get_bbox(part):
-    scene = StaticScene(scene_parts=[part])
-    return np.array(scene._cpp_object.bbox_crs.bounds)
-
-
 def test_scenepart_bbox_extraction(box):
     bbox = box.bbox
     assert isinstance(bbox, BoundingBox)
@@ -574,13 +569,13 @@ def test_scenepart_bbox_updates_after_transformations(box):
 
 
 def check_rotation(box1, box2):
-    bbox1 = get_bbox(box1)
+    bbox1 = np.array(box1.bbox.bounds)
     bbox1[0][1] = bbox1[0][1] * math.sqrt(2)
     bbox1[0][2] = bbox1[0][2] * math.sqrt(2)
     bbox1[1][1] = bbox1[1][1] * math.sqrt(2)
     bbox1[1][2] = bbox1[1][2] * math.sqrt(2)
 
-    bbox2 = get_bbox(box2)
+    bbox2 = np.array(box2.bbox.bounds)
     assert np.allclose(bbox1, bbox2)
 
 
@@ -647,8 +642,8 @@ def test_rotate_scenepart_rotation_center(box_f):
 
     box1.rotate(angle="180 deg", axis=[0, 0, 1.0], rotation_center=[100.0, 0.0, 0.0])
     box2.translate([200.0, 0.0, 0.0])
-    bbox1 = get_bbox(box1)
-    bbox2 = get_bbox(box2)
+    bbox1 =  np.array(box1.bbox.bounds)
+    bbox2 =  np.array(box2.bbox.bounds)
 
     assert np.allclose(bbox1, bbox2)
 
@@ -660,8 +655,8 @@ def test_scale_mesh_scenepart(box_f):
     scale = 2.0
     box2.scale(scale)
 
-    bbox1 = get_bbox(box1)
-    bbox2 = get_bbox(box2)
+    bbox1 = np.array(box1.bbox.bounds)
+    bbox2 = np.array(box2.bbox.bounds)
 
     assert np.allclose(bbox1 * scale, bbox2)
 
@@ -702,8 +697,8 @@ def test_transform_scenepart(box_f):
     offset = np.array([10.0, 0, 0])
     box2.translate(offset)
 
-    bbox1 = get_bbox(box1)
-    bbox2 = get_bbox(box2)
+    bbox1 = np.array(box1.bbox.bounds)
+    bbox2 = np.array(box2.bbox.bounds)
 
     assert np.allclose(bbox1 + offset, bbox2)
 

--- a/tests/python/test_scene.py
+++ b/tests/python/test_scene.py
@@ -661,11 +661,15 @@ def test_scale_mesh_scenepart(box_f):
     assert np.allclose(bbox1 * scale, bbox2)
 
 
-@pytest.mark.parametrize("factory_fixture,scale", 
-                         [("xyz_scenepart_f", 2.0),
-                          ("xyz_scenepart_f", 0.5),
-                          ("vox_f", 2.0),
-                          ("vox_f", 0.5)])
+@pytest.mark.parametrize(
+    "factory_fixture,scale",
+    [
+        ("xyz_scenepart_f", 2.0),
+        ("xyz_scenepart_f", 0.5),
+        ("vox_f", 2.0),
+        ("vox_f", 0.5),
+    ],
+)
 def test_scale_voxelized_scenepart(factory_fixture, scale, request):
     factory = request.getfixturevalue(factory_fixture)
     vox1 = factory()
@@ -677,12 +681,8 @@ def test_scale_voxelized_scenepart(factory_fixture, scale, request):
     bbox2 = np.array(vox2.bbox.bounds)
     assert np.allclose(bbox1 * scale, bbox2)
 
-    half_size1 = np.array(
-        [p.half_size for p in vox1._cpp_object.primitives]
-    )
-    half_size2 = np.array(
-        [p.half_size for p in vox2._cpp_object.primitives]
-    )
+    half_size1 = np.array([p.half_size for p in vox1._cpp_object.primitives])
+    half_size2 = np.array([p.half_size for p in vox2._cpp_object.primitives])
     assert np.allclose(half_size1 * scale, half_size2)
 
     ratio1 = (bbox1[1] - bbox1[0]) / half_size1[0]


### PR DESCRIPTION
For detailedVoxels, the scaling was broken: Only the voxel side length (`halfSize`) was scaled, leading to voxels overflowing for scale factors > 1 and gaps between voxels for scale factors > 1. This has been fixed by also scaling the primitive before (extent of voxel grid and spacing between voxels).

For XYZPointClouds, this has previously been solved with the "holistic" mode. In my opinion, this is not needed anymore after the fix, so I removed it.

The test (for both detailedVoxels and XYZPointClouds) still needs to be implemented, I only added a placeholder in `test:scene.py`.