### PR TITLE
implement scale_center

### DIFF
--- a/python/helios/scene.py
+++ b/python/helios/scene.py
@@ -235,6 +235,10 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         :param to_axis: The image vector to use for the rotation. Must be provided together with the 'from_axis' parameter.
         :param rotation_center: The center to use for the rotation. If omitted, the origin of the coordinate system of the scene part will be used.
         :type quaternion: Optional[Quaternion]
+        :type axis: Optional[R3Vector]
+        :type angle: Optional[Angle]
+        :type to_axis: Optional[R3Vector]
+        :type rotation_center: Optional[R3Vector]
         """
 
         # The rotation object that we want to construct
@@ -295,15 +299,28 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         return self
 
     @validate_call
-    def scale(self, factor: PositiveFloat):
+    def scale(self, factor: PositiveFloat, scale_center: Optional[R3Vector] = None,):
         """Scale the scene part by a factor.
 
         :param factor: The factor to scale the scene part by.
+        :param scale_center: The center to use for the scaling. If omitted, the origin of the coordinate system of the scene part will be used.
         :type factor: PositiveFloat
+        :type scale_center: Optional[R3Vector]
         """
 
+        # maybe shift by the scaling center
+        if scale_center is not None:
+            _helios.translate_scene_part(self._cpp_object, -scale_center)
+
+        # perform the actual scaling
         _helios.scale_scene_part(self._cpp_object, factor)
-        self._append_operation_provenance("scale", factor=factor)
+
+        # undo the shift by the scaling center
+        if scale_center is not None:
+            _helios.translate_scene_part(self._cpp_object, scale_center)
+
+        self._append_operation_provenance("scale", factor=factor, scale_center=scale_center)
+
         return self
 
     @validate_call

--- a/python/helios/scene.py
+++ b/python/helios/scene.py
@@ -225,6 +225,8 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         * An axis and an angle
         * An origin and an image vector
 
+        Exactly one of these must be specified.
+
         Optionally, you may specify a rotation center. If omitted the origin
         of the coordinate system of the scene part will be used.
 
@@ -237,6 +239,7 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         :type quaternion: Optional[Quaternion]
         :type axis: Optional[R3Vector]
         :type angle: Optional[Angle]
+        :type from_axis: Optional[R3Vector]
         :type to_axis: Optional[R3Vector]
         :type rotation_center: Optional[R3Vector]
         """

--- a/python/helios/scene.py
+++ b/python/helios/scene.py
@@ -302,7 +302,11 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         return self
 
     @validate_call
-    def scale(self, factor: PositiveFloat, scale_center: Optional[R3Vector] = None,):
+    def scale(
+        self,
+        factor: PositiveFloat,
+        scale_center: Optional[R3Vector] = None,
+    ):
         """Scale the scene part by a factor.
 
         :param factor: The factor to scale the scene part by.
@@ -322,7 +326,9 @@ class ScenePart(Model, cpp_class=_helios.ScenePart):
         if scale_center is not None:
             _helios.translate_scene_part(self._cpp_object, scale_center)
 
-        self._append_operation_provenance("scale", factor=factor, scale_center=scale_center)
+        self._append_operation_provenance(
+            "scale", factor=factor, scale_center=scale_center
+        )
 
         return self
 

--- a/tests/python/test_scene.py
+++ b/tests/python/test_scene.py
@@ -648,16 +648,21 @@ def test_rotate_scenepart_rotation_center(box_f):
     assert np.allclose(bbox1, bbox2)
 
 
-def test_scale_scenepart_scale_center(box_f):
-    box = box_f()
-    original_bbox = np.array(box.bbox.bounds)
+@pytest.mark.parametrize(
+    "factory_fixture",
+    ["box_f", "xyz_scenepart_f","vox_f"],
+)
+def test_scale_scenepart_scale_center(factory_fixture, request):
+    factory = request.getfixturevalue(factory_fixture)
+    part = factory()
+    original_bbox = np.array(part.bbox.bounds)
 
     center = np.array([100.0, 0.0, 50.0])
     factor = 5.0
-    box.scale(factor, scale_center=center)
+    part.scale(factor, scale_center=center)
 
     expected_bbox = center + (original_bbox - center) * factor
-    assert np.allclose(expected_bbox, np.array(box.bbox.bounds))
+    assert np.allclose(expected_bbox, np.array(part.bbox.bounds))
 
 
 def test_scale_mesh_scenepart(box_f):

--- a/tests/python/test_scene.py
+++ b/tests/python/test_scene.py
@@ -650,7 +650,7 @@ def test_rotate_scenepart_rotation_center(box_f):
 
 @pytest.mark.parametrize(
     "factory_fixture",
-    ["box_f", "xyz_scenepart_f","vox_f"],
+    ["box_f", "xyz_scenepart_f", "vox_f"],
 )
 def test_scale_scenepart_scale_center(factory_fixture, request):
     factory = request.getfixturevalue(factory_fixture)

--- a/tests/python/test_scene.py
+++ b/tests/python/test_scene.py
@@ -648,6 +648,18 @@ def test_rotate_scenepart_rotation_center(box_f):
     assert np.allclose(bbox1, bbox2)
 
 
+def test_scale_scenepart_scale_center(box_f):
+    box = box_f()
+    original_bbox = np.array(box.bbox.bounds)
+
+    center = np.array([100.0, 0.0, 50.0])
+    factor = 5.0
+    box.scale(factor, scale_center=center)
+
+    expected_bbox = center + (original_bbox - center) * factor
+    assert np.allclose(expected_bbox, np.array(box.bbox.bounds))
+
+
 def test_scale_scenepart(box_f):
     box1 = box_f()
     box2 = box_f()


### PR DESCRIPTION
Add a `scale_center` parameter to the `ScenePart.scale` method

fixes #960 