### PR TITLE
Fix/access violation interp traj las

### DIFF
--- a/src/filems/write/core/HeliosWriter.h
+++ b/src/filems/write/core/HeliosWriter.h
@@ -91,7 +91,10 @@ public:
   /**
    * @see filems::HeliosWriter::getOutputFilePath
    */
-  virtual std::string getOutputPath() const { return sfw->getPath(); }
+  virtual std::string getOutputPath() const
+  {
+    return sfw == nullptr ? "" : sfw->getPath();
+  }
 
   /**
    * @brief Get the LAS output flag

--- a/src/filems/write/core/TrajectoryWriter.h
+++ b/src/filems/write/core/TrajectoryWriter.h
@@ -91,7 +91,10 @@ public:
   /**
    * @see filems::TrajectoryWriter::getOutputFilePath
    */
-  inline std::string getOutputPath() const { return sfw->getPath(); }
+  inline std::string getOutputPath() const
+  {
+    return sfw == nullptr ? "" : sfw->getPath();
+  }
 };
 
 }

--- a/src/filems/write/strategies/LasMeasurementWriteStrategy.h
+++ b/src/filems/write/strategies/LasMeasurementWriteStrategy.h
@@ -167,7 +167,8 @@ protected:
     // Populate LAS point (extra bytes attributes)
     lp.set_attribute(ewAttrStart, F64(m.echo_width));
     lp.set_attribute(fwiAttrStart, I32(m.fullwaveIndex));
-    lp.set_attribute(hoiAttrStart, I32(std::stoi(m.hitObjectId)));
+    I32 const hoi = m.hitObjectId.empty() ? 0 : I32(std::stoi(m.hitObjectId));
+    lp.set_attribute(hoiAttrStart, hoi);
     lp.set_attribute(ampAttrStart, F64(m.intensity));
   }
 };

--- a/src/platform/InterpolatedMovingPlatform.cpp
+++ b/src/platform/InterpolatedMovingPlatform.cpp
@@ -120,4 +120,11 @@ InterpolatedMovingPlatform::toTrajectoryTime(double const t)
     h = t - tf->getFpiem().getT();
     tf->getFpiem().eval(h);
   }
+  // Keep DesignTrajectoryFunction::lastTime in sync with the fpiem's
+  // internal clock, otherwise the next eval(t) call (driven by
+  // stepLoop time) computes its delta against a stale lastTime left
+  // over from before this seek (e.g. from a prior leg or a previous
+  // survey run), which can send the iterative solver a large negative
+  // step it is not designed to handle.
+  tf->setLastTime(t);
 }

--- a/src/sim/core/SurveyPlayback.cpp
+++ b/src/sim/core/SurveyPlayback.cpp
@@ -153,7 +153,13 @@ SurveyPlayback::estimateTemporalLegProgress()
   double const t0 = imp->getCurrentLegStartTime();
   double const t = imp->getStepLoop().getCurrentTime();
   double const Dt = imp->getCurrentLegTimeDiff();
-  return (int)(100 * t / (t0 + Dt));
+  double const legDuration = t0 + Dt;
+  // Zero-duration legs (e.g. TELEPORT/STOP legs, which have Dt == 0 and can
+  // start at t0 == 0) would otherwise divide by zero here; such legs are
+  // considered complete as soon as they start.
+  if (legDuration <= 0.0)
+    return 100;
+  return (int)(100 * t / legDuration);
 }
 
 void

--- a/tests/python/test_survey.py
+++ b/tests/python/test_survey.py
@@ -677,7 +677,7 @@ def test_run_interpolated_survey():
 def test_run_interpolated_survey_teleport_first_leg_on_disk_output(tmp_path):
     """
     Regression test: an interpolated-platform survey whose first leg has
-    `teleport_to_start=True`, written to on-disk LAZ, used to crash the 
+    `teleport_to_start=True`, written to on-disk LAZ, used to crash the
     process (silent access violation).
     """
     execution_settings = ExecutionSettings(num_threads=1)

--- a/tests/python/test_survey.py
+++ b/tests/python/test_survey.py
@@ -674,6 +674,58 @@ def test_run_interpolated_survey():
     assert np.allclose(t1["position"][-1], t2["position"][-1], rtol=1e-1, atol=1e-1)
 
 
+def test_run_interpolated_survey_teleport_first_leg_on_disk_output(tmp_path):
+    """
+    Regression test: an interpolated-platform survey whose first leg has
+    `teleport_to_start=True`, written to on-disk LAZ, used to crash the 
+    process (silent access violation).
+    """
+    execution_settings = ExecutionSettings(num_threads=1)
+
+    scanner_settings = ScannerSettings(
+        is_active=True,
+        pulse_frequency=2000,
+        scan_frequency=20,
+        scan_angle=0,
+        trajectory_time_interval=0.05,
+    )
+    trajectory_settings = TrajectorySettings(
+        start_time=0, end_time=0.2, teleport_to_start=True
+    )
+    trajectory = load_traj_csv(
+        csv="data/trajectories/flyandrotate.trj",
+        xIndex=4,
+        yIndex=5,
+        zIndex=6,
+        rollIndex=1,
+        pitchIndex=2,
+        yawIndex=3,
+    )
+    scene = StaticScene.from_xml("data/scenes/demo/box_scene.xml")
+    platform = Platform.load_interpolate_platform(
+        trajectory=trajectory,
+        platform_file="data/platforms.xml",
+        platform_id="sr22",
+        interpolation_method="ARINC 705",
+        sync_gps_time=True,
+    )
+    survey = Survey(scanner=riegl_lms_q560(), platform=platform, scene=scene)
+    survey.add_leg(
+        scanner_settings=scanner_settings, trajectory_settings=trajectory_settings
+    )
+
+    output_path = survey.run(
+        format=OutputFormat.LAZ,
+        output_dir=tmp_path,
+        execution_settings=execution_settings,
+    )
+
+    files = list(output_path.rglob("*.laz"))
+    assert len(files) == 1
+    las = laspy.read(files[0])
+    assert len(las.points) > 0
+
+
 def test_survey_run_with_scene_fixture(scene):
     """
     Test that a survey can be run with an in-memory scene.


### PR DESCRIPTION
I observed a silent crash/abort when using interpolated trajectories with `teleport_to_start=True` and LAZ (on-disk) output. Workarounds were setting `teleport_to_start=False` or instead using the LASPY output and then writing to LAZ file from the script. This PR fixes this and also adds some additional guards that were found during debugging.

- `HeliosWriter::getOutputPath` / `TrajectoryWriter::getOutputPath` — null-guard the underlying file writer (`sfw`) instead of dereferencing it unconditionally. This is the fix for the reported crash: a `TrajectorySettings(teleport_to_start=True)` leg inserts a synthetic, scanner-inactive "teleport" leg as leg 0. `SurveyPlayback::prepareOutput()` skips writer configuration for inactive legs, so `sfw` stays null. The very first `LEG_START` hook fires before any leg has run, calling `resolveMeasurementOutputPath()` → `getOutputPath()`, which dereferenced that null `sfw` and crashed the process outright (an access violation, not a catchable exception — hence the silent abort). It only affected on-disk LAS/LAZ output because in-memory (NPY/laspy) output never reaches this code path. The fix returns an empty path for a not-yet-configured writer instead of crashing.

Further improvements:

- `LasMeasurementWriteStrategy::measurementToPoint` — guard the `hitObjectId` → `hoiAttrStart` conversion against an empty string (`std::stoi("")` throws `std::invalid_argument`). An empty `hitObjectId` occurs whenever a binned full-waveform echo has no matching ray/scene intersection; the LAS/LAZ writer would crash on this uncaught exception while the NPY/laspy path already guarded for it, cf. https://github.com/3dgeo-heidelberg/helios/blob/13198b88f6a3ad88eba302250eef92b34375fde5/src/python/NumpyArrayConversion.h#L111

- `InterpolatedMovingPlatform::toTrajectoryTime` — keep `DesignTrajectoryFunction::lastTime` in sync when reseeking the trajectory's iterative solver. `toTrajectoryTime()` resets the solver's internal clock (`fpiem`/`pclsf`) directly but never touched `lastTime`, which `eval()` uses to compute its step size. After the solver had advanced (e.g. across legs, or across a second `survey.run()` on the same platform object), the next `eval()` call computed a large stale delta, corrupting the interpolated position/attitude. Now `lastTime` is reset alongside the solver.

- `SurveyPlayback::estimateTemporalLegProgress` — avoid dividing by zero when estimating progress for a zero-duration leg (the same synthetic teleport/stop legs above have `currentLegTimeDiff == 0`, and can also start at `currentLegStartTime == 0`). This produced a NaN/inf progress value cast to `int`, undefined behavior. Such legs now report 100% progress immediately.

Debugging was supported by Claude Code.